### PR TITLE
Reduce clipping through tool and add fade

### DIFF
--- a/Assets/Materials/Black.mat
+++ b/Assets/Materials/Black.mat
@@ -9,12 +9,13 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Black
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_ShaderKeywords: _ALPHAPREMULTIPLY_ON
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -59,19 +60,19 @@ Material:
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
-    - _DstBlend: 0
+    - _DstBlend: 10
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _Metallic: 0
-    - _Mode: 0
+    - _Mode: 3
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
-    - _ZWrite: 1
+    - _ZWrite: 0
     m_Colors:
     - _Color: {r: 0, g: 0, b: 0, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Scripts/Tool.cs
+++ b/Assets/Scripts/Tool.cs
@@ -6,17 +6,37 @@ using Valve.VR;
 public class Tool : MonoBehaviour {
     HapticFeedback hapticFeedback;
     SteamVR_Behaviour_Pose hand;
+    Collider thisCollider;  // calling it "collider" triggers a useless warning so it'll be called "thisCollider" instead
     public float forceMultiplier = 5;
+    readonly float velocityUpperThreshold = 1;  // anything above this value will be considered "fast" and treated differently to avoid clipping
 
     // Start is called before the first frame update
     void Start() {
         hapticFeedback = GetComponentInParent<HapticFeedback>();
         hand = GetComponentInParent<SteamVR_Behaviour_Pose>();
+        thisCollider = GetComponent<Collider>();
     }
 
+    private void Update() {
+        float handVelocityMagnitude = hand.GetVelocity().magnitude;
+        if (handVelocityMagnitude < velocityUpperThreshold) {
+            thisCollider.isTrigger = false;
+        } else {
+            thisCollider.isTrigger = true;
+        }
+    }
+
+    // Used for slow movement
     private void OnCollisionEnter(Collision collision) {
         hapticFeedback.Vibrate(0.1f, 100, 15);
         ExertForce(collision.collider.GetComponent<Rigidbody>());
+    }
+
+    // Used for fast movement
+    private void OnTriggerEnter(Collider other) {
+        hapticFeedback.Vibrate(0.1f, 100, 30);
+        // TODO: account for bounce using normal of supposed collision point
+        ExertForce(other.GetComponent<Rigidbody>());
     }
 
     // Exert a force on the other rigidbody

--- a/Assets/Scripts/Tool.cs
+++ b/Assets/Scripts/Tool.cs
@@ -7,7 +7,8 @@ public class Tool : MonoBehaviour {
     HapticFeedback hapticFeedback;
     SteamVR_Behaviour_Pose hand;
     Collider thisCollider;  // calling it "collider" triggers a useless warning so it'll be called "thisCollider" instead
-    float forceMultiplier = 0.4f;
+    readonly float forceMultiplier = 0.25f;
+    readonly float angularVelocityMultiplier = 0.01f;  // Used to make behaviour more consistent between flicks and full-body swings
     List<Material> materials = new List<Material>();
     readonly Renderer[] renderers;
     float fadeStartTime;
@@ -105,6 +106,6 @@ public class Tool : MonoBehaviour {
     private void ExertForce(Rigidbody r) {
         // TODO: Improve accuracy of physics and possibly add spin
         hand.GetVelocitiesAtTimeOffset(-0.1f, out Vector3 oldVelocity, out Vector3 a);
-        r.AddForce((hand.GetVelocity() - oldVelocity) / 0.1f * forceMultiplier, ForceMode.Impulse);
+        r.AddForce((hand.GetVelocity() - oldVelocity) * (1 + hand.GetAngularVelocity().magnitude * angularVelocityMultiplier) / 0.1f * forceMultiplier, ForceMode.Impulse);
     }
 }

--- a/Docs/Them Lit FYP Information.md
+++ b/Docs/Them Lit FYP Information.md
@@ -38,6 +38,7 @@ The project aims to make exercising fun with VR and Sensors. Body movements will
 - The maximum number of balls allowed in the game is decided by the game host.
 - The duration of a match, as well as the number of matches to count as a game, are also decided by the host.
 - In case of the ball coming to a stop, destroy and spawn back in players hand.
+- If a player's hand remains stationary, the tool will become transparent and balls will not collide with it.
 
 **Design Sketches:**
 


### PR DESCRIPTION
**Description**
Previously, when swinging too fast, the ball flies off in the opposite direction. This is due to the ball being more than halfway through the tool in one physics timestep (from not being in contact the frame before). The exertion of force in one direction hence causes the ball to bounce off the non-trigger collider component on the tool.

In [5fa7e8e](https://github.com/VRFYP2019/Not-Dodgeball/commit/5fa7e8e7098cb9660ae40a50de3e05de0a080b04), the `isTrigger` field will be turned on for fast movements to prevent this issue.
![smackfast](https://user-images.githubusercontent.com/28438978/64344561-47496000-d021-11e9-96a7-fc3e3475247a.gif)


The work on this inspired [4278799](https://github.com/VRFYP2019/Not-Dodgeball/commit/4278799435eb521858bed4ce09c9e605bfdc2dad), which makes the tool fade on AFK.
![fade](https://user-images.githubusercontent.com/28438978/64344658-7b248580-d021-11e9-803d-3baf632c5e0c.gif)
Note that this requires the rendering mode on the materials involved to not be "opaque".
![image](https://user-images.githubusercontent.com/28438978/64345177-6dbbcb00-d022-11e9-8131-c6f413d326b6.png)

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
- Very mildly inaccurate physics
- May cause game to be more complicated than required (although it adds further incentive to move)

**Test Plan**
Checkout into this branch and hit some balls. Then AFK. Then hit some balls again and repeat.