### PR TITLE
Update goalpost + dummy goal

### DIFF
--- a/Assets/Prefabs/DummyGoal.prefab
+++ b/Assets/Prefabs/DummyGoal.prefab
@@ -1,0 +1,123 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6160307769856202025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6160307769856202030}
+  m_Layer: 0
+  m_Name: DummyGoal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6160307769856202030
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6160307769856202025}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2013557291438556211}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &6160307769567809648
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6160307769856202030}
+    m_Modifications:
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_Name
+      value: GoalPost
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616876908641741, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: goalPosition
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616876908641741, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: offsetZ
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616876908641741, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerColor
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68133f0ebc3140b419b63fd9ee0e7709, type: 3}
+--- !u!4 &2013557291438556211 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    type: 3}
+  m_PrefabInstance: {fileID: 6160307769567809648}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/DummyGoal.prefab.meta
+++ b/Assets/Prefabs/DummyGoal.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83bff4daf25c2f642ac384bc52b8c9fd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -262,7 +262,73 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
---- !u!43 &193408705
+--- !u!1 &496918892
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 496918895}
+  - component: {fileID: 496918894}
+  - component: {fileID: 496918893}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &496918893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496918892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &496918894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496918892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &496918895
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496918892}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1696970910}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!43 &530690782
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -425,72 +491,6 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &496918892
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 496918895}
-  - component: {fileID: 496918894}
-  - component: {fileID: 496918893}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &496918893
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 496918892}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
---- !u!114 &496918894
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 496918892}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &496918895
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 496918892}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1696970910}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &711405197
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -628,6 +628,11 @@ PrefabInstance:
       propertyPath: blueGoal
       value: 
       objectReference: {fileID: 1824701090}
+    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: orangeGoal
+      value: 
+      objectReference: {fileID: 1919894850}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
 --- !u!224 &711405198 stripped
@@ -648,40 +653,90 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b1b161d10bc2ee74ea257c9559619dbc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!21 &1300069175
-Material:
-  serializedVersion: 6
+--- !u!1001 &1350234834
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _AlphaTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - PixelSnap: 0
-    - _EnableExternalAlpha: 0
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _Flip: {r: 1, g: 1, b: 1, a: 1}
-    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1628075916}
+    m_Modifications:
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_Name
+      value: GoalPost
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616876908641741, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: goalPosition
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616876908641741, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: offsetZ
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616876908641741, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerColor
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68133f0ebc3140b419b63fd9ee0e7709, type: 3}
 --- !u!1001 &1384528159
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -753,12 +808,12 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 1300069175}
+      objectReference: {fileID: 1386089580}
     - target: {fileID: 1137926388642097178, guid: 9ea8269726e18514d89b8730fd18a3dc,
         type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 193408705}
+      objectReference: {fileID: 530690782}
     - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
         type: 3}
       propertyPath: m_LocalRotation.x
@@ -831,6 +886,40 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9ea8269726e18514d89b8730fd18a3dc, type: 3}
+--- !u!21 &1386089580
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - PixelSnap: 0
+    - _EnableExternalAlpha: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1606914381
 GameObject:
   m_ObjectHideFlags: 0
@@ -922,6 +1011,37 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 45, y: -135, z: 0}
+--- !u!1 &1628075915
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1628075916}
+  m_Layer: 0
+  m_Name: DummyGoal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1628075916
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1628075915}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1919894851}
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1696970909
 GameObject:
   m_ObjectHideFlags: 0
@@ -1146,6 +1266,11 @@ PrefabInstance:
       propertyPath: blueGoal
       value: 
       objectReference: {fileID: 1824701090}
+    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: orangeGoal
+      value: 
+      objectReference: {fileID: 1919894850}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
 --- !u!224 &1777842403 stripped
@@ -1171,6 +1296,18 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 2550220586530560703, guid: 9ea8269726e18514d89b8730fd18a3dc,
     type: 3}
   m_PrefabInstance: {fileID: 1384528159}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1919894850 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    type: 3}
+  m_PrefabInstance: {fileID: 1350234834}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1919894851 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    type: 3}
+  m_PrefabInstance: {fileID: 1350234834}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1965531663
 GameObject:

--- a/Assets/Scripts/Goal.cs
+++ b/Assets/Scripts/Goal.cs
@@ -7,14 +7,36 @@ using UnityEngine;
 // Goalpost is to follow player's position and Y-axis rotation (Yaw)
 // Goalpost cannot move outside the bounds of the room
 public class Goal : MonoBehaviour {
-    private static readonly float offsetX = 0f, offsetY = -0.5f, offsetZ = -1f;
+    private static readonly float X_OFFSET = 0f, Y_OFFSET = 0f, Z_OFFSET = -1.25f;
     private static readonly float X_MIN = -2f, X_MAX = 2f, Y_MIN = 0.5f, Y_MAX = 3.5f, Z_MIN = -8f, Z_MAX =2f;
+    private static readonly float BLUE_Y_ROTATION = 0f, ORANGE_Y_ROTATION = 180f;
+    
     private Vector3 parentPos, newPos;
     private int playerScore;
+    private float yRotation;
+
+    // TODO: Change how player color is set on init for multiplayer support
+    // Temp solution, we could check for the parent.name or other indicators of player color in future
+    private enum PlayerColor {
+        BLUE,
+        ORANGE
+    }
+
+    [SerializeField]
+    private PlayerColor playerColor = PlayerColor.ORANGE;
 
     // Start is called before the first frame update
     void Start() {
         ResetPlayerScore();
+        InitRotation();
+    }
+
+    private void InitRotation() {
+        if (playerColor == PlayerColor.BLUE) {
+            yRotation = BLUE_Y_ROTATION;
+        } else {
+            yRotation = ORANGE_Y_ROTATION;
+        }
     }
 
     // Update is called once per frame
@@ -25,25 +47,15 @@ public class Goal : MonoBehaviour {
     private void HandleGoalPosition() {
         parentPos = transform.parent.position;
         // Prevent goal from exceeding room bounds
-        newPos.x = Mathf.Clamp(parentPos.x + offsetX, X_MIN, X_MAX);
-        newPos.y = Mathf.Clamp(parentPos.y + offsetY, Y_MIN, Y_MAX);
-        newPos.z = Mathf.Clamp(parentPos.z + offsetZ, Z_MIN, Z_MAX);
+        newPos.x = Mathf.Clamp(parentPos.x + X_OFFSET, X_MIN, X_MAX);
+        newPos.y = Mathf.Clamp(parentPos.y + Y_OFFSET, Y_MIN, Y_MAX);
+        newPos.z = Mathf.Clamp(parentPos.z + Z_OFFSET, Z_MIN, Z_MAX);
         UpdateGoalPosition(newPos);
     }
 
     private void UpdateGoalPosition(Vector3 pos) {
         transform.position = pos;
-        transform.rotation = GeneralizedLookRotation(Vector3.up, Vector3.up, Vector3.back, transform.parent.forward);
-    }
-
-    // Takes a vector in local coordinates, localExactAxis, and rotate it to point exactly along globalExactAxis in world coordinates.
-    private Quaternion GeneralizedLookRotation(Vector3 localExactAxis, Vector3 globalExactAxis, Vector3 localApproxAxis, Vector3 globalApproxAxis) {
-        // Rotate chosen local axes into a standard orientation.
-        Quaternion standardize = Quaternion.Inverse( Quaternion.LookRotation(localExactAxis, localApproxAxis));
-        // Rotate standard orientation to point to the chosen global axes.
-        Quaternion turn = Quaternion.LookRotation(globalExactAxis, globalApproxAxis);
-        // Chain both operations to rotate the local axes to the global axes.
-        return turn * standardize;
+        transform.eulerAngles = new Vector3 (0, yRotation, 0);
     }
 
     void OnTriggerEnter(Collider col) {

--- a/Assets/Scripts/ScoreBoard.cs
+++ b/Assets/Scripts/ScoreBoard.cs
@@ -10,8 +10,8 @@ public class ScoreBoard : MonoBehaviour {
     public Text blueScoreText, orangeScoreText, timeLeftText;
     public bool isTimeOver;
     [SerializeField]
-    private GameObject blueGoal = null; //, orangeGoal = null;
-    private Goal blueGoalScript; //, orangeGoalScript;
+    private GameObject blueGoal = null, orangeGoal = null;
+    private Goal blueGoalScript, orangeGoalScript;
     private float timeLeft;
     private IEnumerator restartPromptCoroutine;
     private static readonly string timeOver = "TIME OVER";
@@ -26,12 +26,12 @@ public class ScoreBoard : MonoBehaviour {
     private void Init() {
         timeLeft = GameManager.Instance.gameDuration;
         blueScoreText.text = "0";
-        //orangeScoreText.text = "0";
+        orangeScoreText.text = "0";
         timeLeftText.text = timeLeft.ToString();
         isTimeOver = false;
 
         blueGoalScript = blueGoal.GetComponentInChildren<Goal>();
-        //orangeGoalScript = orangeGoal.GetComponentsInChildren<Goal>();
+        orangeGoalScript = orangeGoal.GetComponentInChildren<Goal>();
     }
 
     // Update is called once per frame
@@ -68,14 +68,14 @@ public class ScoreBoard : MonoBehaviour {
     // Displays scores of both players
     private void UpdateDisplayScores() {
         blueScoreText.text = blueGoalScript.GetPlayerScore().ToString();
-        //orangeScoreText.text = orangeGoalScript.GetPlayerScore().ToString();
+        orangeScoreText.text = orangeGoalScript.GetPlayerScore().ToString();
     }
 
     public void Restart() {
         StopCoroutine(restartPromptCoroutine);
         // TODO: remove these lines after moving scoring tracking from Goal to something else
         blueGoalScript.ResetPlayerScore();
-        //orangeGoalScript.ResetPlayerScore();
+        orangeGoalScript.ResetPlayerScore();
         Init();
     }
 


### PR DESCRIPTION
**Description**
![image](https://user-images.githubusercontent.com/28535405/64939729-8df65000-d894-11e9-8c6d-7c4afcf5905e.png)

- Lock the goalpost to only face the front for both colors.
- Some minor adjustments to the goalposts position offsets.
- Added in a dummy goal on the blue side for easier testing.
- Updated scoreboard to count points for the dummy goal

**Scene Hierarchy**
![image](https://user-images.githubusercontent.com/28535405/64939958-3c9a9080-d895-11e9-9603-d0bfb9f97192.png)

@khooroko
@lyhvictoria

**Impact**
If impact is minor, no need for the reviewer to check out the branch to test locally before approval
- [ ] Major
- [x] Medium
- [ ] Minor

**Risks**
Any foreseeable difficulty in extending from this implementation?
Any files such as prefabs and scenes may arise in conflict?
Any possible regression?

**Test Plan**
How to verify that this PR works and does not break anything else?