### PR TITLE
Improve spawning UX

### DIFF
--- a/Assets/Images/ArmScreen.png
+++ b/Assets/Images/ArmScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1604aec434e545b43a8d129febcf0daad041c90844759b4912724023fccebe6
+size 3361

--- a/Assets/Images/ArmScreen.png.meta
+++ b/Assets/Images/ArmScreen.png.meta
@@ -1,0 +1,90 @@
+fileFormatVersion: 2
+guid: a9ae2f82b84fbb944911aa0586afe027
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 10
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - serializedVersion: 2
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/BallManager.prefab
+++ b/Assets/Prefabs/BallManager.prefab
@@ -1,5 +1,35 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &67109755
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 67109756}
+  m_Layer: 0
+  m_Name: Player2BallQueue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &67109756
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 67109755}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2333401913653627726}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &459384113
 GameObject:
   m_ObjectHideFlags: 0
@@ -37,6 +67,16 @@ Transform:
   - {fileID: 3913365059269433326}
   - {fileID: 3913365058882905808}
   - {fileID: 3913365059119990602}
+  - {fileID: 3913365058973440445}
+  - {fileID: 3913365059574891623}
+  - {fileID: 3913365059594324518}
+  - {fileID: 3913365060163511878}
+  - {fileID: 3913365059945560571}
+  - {fileID: 3913365059426753714}
+  - {fileID: 3913365060081963892}
+  - {fileID: 3913365059658638574}
+  - {fileID: 3913365058896582134}
+  - {fileID: 3913365059119167529}
   m_Father: {fileID: 2333401913653627726}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -70,6 +110,36 @@ Transform:
   m_Father: {fileID: 2333401913653627726}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1019568740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1019568741}
+  m_Layer: 0
+  m_Name: Player1BallQueue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1019568741
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1019568740}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2333401913653627726}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2333401913653627724
 GameObject:
   m_ObjectHideFlags: 0
@@ -100,6 +170,8 @@ Transform:
   m_Children:
   - {fileID: 459384114}
   - {fileID: 804255467}
+  - {fileID: 1019568741}
+  - {fileID: 67109756}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -117,8 +189,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   BallTypes:
   - {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+  playerBallQueues:
+  - {fileID: 1019568741}
+  - {fileID: 67109756}
   ballPool: {fileID: 459384114}
-  poolPointer: 0
   activeBalls: {fileID: 804255467}
 --- !u!1001 &127032525
 PrefabInstance:
@@ -440,6 +514,196 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 211611420}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &216010879
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365059119167529 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 216010879}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &357609963
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365058973440445 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 357609963}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &365186016
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -599,6 +863,101 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
     type: 3}
   m_PrefabInstance: {fileID: 404408926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &506330528
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365058896582134 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 506330528}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &519900806
 PrefabInstance:
@@ -760,6 +1119,101 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 723916181}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &750374072
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365059658638574 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 750374072}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &760758885
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -839,6 +1293,576 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
     type: 3}
   m_PrefabInstance: {fileID: 760758885}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &810721904
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365059594324518 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 810721904}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &834284593
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365059574891623 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 834284593}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1045935332
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365059426753714 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 1045935332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1386319376
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365060163511878 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 1386319376}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1464171298
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365060081963892 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 1464171298}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1604571565
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 459384114}
+    m_Modifications:
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_Name
+      value: Sphere (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975818, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    - target: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.099999994
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e90c55a1d8ea4954fb9f8c81261ac424, type: 3}
+--- !u!4 &3913365059945560571 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3913365059330975830, guid: e90c55a1d8ea4954fb9f8c81261ac424,
+    type: 3}
+  m_PrefabInstance: {fileID: 1604571565}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1671384601
 PrefabInstance:

--- a/Assets/Prefabs/[CameraRig].prefab
+++ b/Assets/Prefabs/[CameraRig].prefab
@@ -90,12 +90,94 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 957b3325e4db9c9419a7d3f4b4046aed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  click:
-    actionPath: /actions/default/in/InteractUI
-    needsReinit: 0
-  throwingForce: 100
-  spawnDelay: 0.25
   currentBall: {fileID: 0}
+--- !u!1 &27471462578534389
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4735820730571890139}
+  - component: {fileID: 6993810812480866730}
+  - component: {fileID: 1845085599265688766}
+  - component: {fileID: 3887328701048747990}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4735820730571890139
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27471462578534389}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: -0.28}
+  m_LocalScale: {x: 0.06, y: 0.125, z: 1.2400005}
+  m_Children:
+  - {fileID: 2251173616441560076}
+  m_Father: {fileID: 5482147133088467320}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6993810812480866730
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27471462578534389}
+  m_CullTransparentMesh: 0
+--- !u!114 &1845085599265688766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27471462578534389}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71fde0d6d64042f4ebe71b1d232e1bca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1120754112370808448}
+--- !u!114 &3887328701048747990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27471462578534389}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Texture: {fileID: 2800000, guid: a9ae2f82b84fbb944911aa0586afe027, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &1137501423276051140
 GameObject:
   m_ObjectHideFlags: 0
@@ -454,6 +536,7 @@ Transform:
   m_Children:
   - {fileID: 1137926386878814539}
   - {fileID: 47999868}
+  - {fileID: 3602085649742317381}
   m_Father: {fileID: 1137926388645089984}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -653,7 +736,9 @@ MonoBehaviour:
   grab:
     actionPath: /actions/default/in/GrabGrip
     needsReinit: 0
-  _isSpawning: 0
+  trigger:
+    actionPath: /actions/default/in/InteractUI
+    needsReinit: 0
 --- !u!1 &1137926388645351496
 GameObject:
   m_ObjectHideFlags: 0
@@ -686,6 +771,7 @@ Transform:
   m_Children:
   - {fileID: 1137926387355582916}
   - {fileID: 3958835350176539304}
+  - {fileID: 5482147133088467320}
   m_Father: {fileID: 1137926388645089984}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -760,6 +846,520 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isSpawning: 0
+--- !u!1 &3436510034977330877
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3147587373584111772}
+  - component: {fileID: 979856449386454863}
+  - component: {fileID: 1452502134256291935}
+  - component: {fileID: 1674139237235277067}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3147587373584111772
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3436510034977330877}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: -0.28}
+  m_LocalScale: {x: 0.06, y: 0.125, z: 1.2400005}
+  m_Children:
+  - {fileID: 6536293857369809177}
+  m_Father: {fileID: 3602085649742317381}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &979856449386454863
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3436510034977330877}
+  m_CullTransparentMesh: 0
+--- !u!114 &1452502134256291935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3436510034977330877}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71fde0d6d64042f4ebe71b1d232e1bca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1120754112370808448}
+--- !u!114 &1674139237235277067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3436510034977330877}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Texture: {fileID: 2800000, guid: a9ae2f82b84fbb944911aa0586afe027, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!1 &4451893456579300461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3602085649742317381}
+  - component: {fileID: 3222243033659112936}
+  - component: {fileID: 5904591514685043110}
+  - component: {fileID: 8149106635597977528}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3602085649742317381
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4451893456579300461}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7618103146517274539}
+  - {fileID: 3147587373584111772}
+  m_Father: {fileID: 1137926388645019186}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &3222243033659112936
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4451893456579300461}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &5904591514685043110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4451893456579300461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &8149106635597977528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4451893456579300461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &4486390492415611977
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5935854702022005454}
+  - component: {fileID: 4635297393671949108}
+  - component: {fileID: 7137724123400009736}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5935854702022005454
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4486390492415611977}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: -0.25}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5482147133088467320}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4635297393671949108
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4486390492415611977}
+  m_CullTransparentMesh: 0
+--- !u!114 &7137724123400009736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4486390492415611977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 91b480a4153c3a549ac9da4a987977e7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!1 &5504501207453960532
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5482147133088467320}
+  - component: {fileID: 5282649799116571732}
+  - component: {fileID: 154358662671879319}
+  - component: {fileID: 8972529697286306968}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5482147133088467320
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5504501207453960532}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5935854702022005454}
+  - {fileID: 4735820730571890139}
+  m_Father: {fileID: 1137926388645075694}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &5282649799116571732
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5504501207453960532}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &154358662671879319
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5504501207453960532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &8972529697286306968
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5504501207453960532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &5626849937731415348
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2251173616441560076}
+  - component: {fileID: 7919192886919188028}
+  - component: {fileID: 7305213267779387151}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2251173616441560076
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5626849937731415348}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.010000006, y: 0.010000003, z: 0.05000001}
+  m_Children: []
+  m_Father: {fileID: 4735820730571890139}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7919192886919188028
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5626849937731415348}
+  m_CullTransparentMesh: 0
+--- !u!114 &7305213267779387151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5626849937731415348}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 19
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 77
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: TEXT
+--- !u!1 &8117514831725027400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7618103146517274539}
+  - component: {fileID: 5708718462626215357}
+  - component: {fileID: 4150599596789508872}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7618103146517274539
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8117514831725027400}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: -0.25}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3602085649742317381}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5708718462626215357
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8117514831725027400}
+  m_CullTransparentMesh: 0
+--- !u!114 &4150599596789508872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8117514831725027400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 91b480a4153c3a549ac9da4a987977e7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!1 &8687963233211831134
 GameObject:
   m_ObjectHideFlags: 0
@@ -850,12 +1450,86 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 957b3325e4db9c9419a7d3f4b4046aed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  click:
-    actionPath: /actions/default/in/InteractUI
-    needsReinit: 0
-  throwingForce: 100
-  spawnDelay: 0.25
   currentBall: {fileID: 0}
+--- !u!1 &9014699199918430205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6536293857369809177}
+  - component: {fileID: 4936968142247692300}
+  - component: {fileID: 3818643957924045661}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6536293857369809177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9014699199918430205}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.010000006, y: 0.010000003, z: 0.05000001}
+  m_Children: []
+  m_Father: {fileID: 3147587373584111772}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4936968142247692300
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9014699199918430205}
+  m_CullTransparentMesh: 0
+--- !u!114 &3818643957924045661
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9014699199918430205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 19
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 77
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: TEXT
 --- !u!1001 &1217674946
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/ImproveSpawnScene.unity
+++ b/Assets/Scenes/ImproveSpawnScene.unity
@@ -328,198 +328,7 @@ Transform:
   m_Father: {fileID: 1696970910}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &711405197
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1696970910}
-    m_Modifications:
-    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_Name
-      value: ScoreBoardSideB
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 5.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 200
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.015
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.015
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: blueGoal
-      value: 
-      objectReference: {fileID: 1824701090}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
---- !u!224 &711405198 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-    type: 3}
-  m_PrefabInstance: {fileID: 711405197}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &711405199 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
-    type: 3}
-  m_PrefabInstance: {fileID: 711405197}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1b161d10bc2ee74ea257c9559619dbc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!21 &911775129
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _AlphaTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - PixelSnap: 0
-    - _EnableExternalAlpha: 0
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _Flip: {r: 1, g: 1, b: 1, a: 1}
-    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
---- !u!43 &1285964074
+--- !u!43 &526487150
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -682,6 +491,197 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1001 &711405197
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1696970910}
+    m_Modifications:
+    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Name
+      value: ScoreBoardSideB
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: blueGoal
+      value: 
+      objectReference: {fileID: 1824701090}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
+--- !u!224 &711405198 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 711405197}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &711405199 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 711405197}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1b161d10bc2ee74ea257c9559619dbc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!21 &977977697
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - PixelSnap: 0
+    - _EnableExternalAlpha: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1001 &1384528159
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -753,12 +753,12 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 911775129}
+      objectReference: {fileID: 977977697}
     - target: {fileID: 1137926388642097178, guid: 9ea8269726e18514d89b8730fd18a3dc,
         type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 1285964074}
+      objectReference: {fileID: 526487150}
     - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
         type: 3}
       propertyPath: m_LocalRotation.x

--- a/Assets/Scenes/ImproveSpawnScene.unity
+++ b/Assets/Scenes/ImproveSpawnScene.unity
@@ -328,7 +328,164 @@ Transform:
   m_Father: {fileID: 1696970910}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &526487150
+--- !u!1001 &711405197
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1696970910}
+    m_Modifications:
+    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Name
+      value: ScoreBoardSideB
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: blueGoal
+      value: 
+      objectReference: {fileID: 1824701090}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
+--- !u!224 &711405198 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 711405197}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &711405199 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 711405197}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1b161d10bc2ee74ea257c9559619dbc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!43 &1228169307
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -491,197 +648,6 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1001 &711405197
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1696970910}
-    m_Modifications:
-    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_Name
-      value: ScoreBoardSideB
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 5.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 200
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.015
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.015
-      objectReference: {fileID: 0}
-    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
-        type: 3}
-      propertyPath: blueGoal
-      value: 
-      objectReference: {fileID: 1824701090}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
---- !u!224 &711405198 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
-    type: 3}
-  m_PrefabInstance: {fileID: 711405197}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &711405199 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
-    type: 3}
-  m_PrefabInstance: {fileID: 711405197}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b1b161d10bc2ee74ea257c9559619dbc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!21 &977977697
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _AlphaTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - PixelSnap: 0
-    - _EnableExternalAlpha: 0
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _Flip: {r: 1, g: 1, b: 1, a: 1}
-    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1001 &1384528159
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -753,12 +719,12 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 977977697}
+      objectReference: {fileID: 1443746029}
     - target: {fileID: 1137926388642097178, guid: 9ea8269726e18514d89b8730fd18a3dc,
         type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 526487150}
+      objectReference: {fileID: 1228169307}
     - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
         type: 3}
       propertyPath: m_LocalRotation.x
@@ -831,6 +797,40 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9ea8269726e18514d89b8730fd18a3dc, type: 3}
+--- !u!21 &1443746029
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - PixelSnap: 0
+    - _EnableExternalAlpha: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1606914381
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/ImproveSpawnScene.unity
+++ b/Assets/Scenes/ImproveSpawnScene.unity
@@ -1,0 +1,1423 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18154666, g: 0.22718978, b: 0.30740848, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+  m_LightingDataAsset: {fileID: 112000000, guid: e40f7bf9c721a6f49a2eae16fe81ffdc,
+    type: 2}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &1509892
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4165734954415435633, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_Name
+      value: GameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435632, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: scoreBoards.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165734954415435632, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: scoreBoards.Array.data[0]
+      value: 
+      objectReference: {fileID: 1777842404}
+    - target: {fileID: 4165734954415435632, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: scoreBoards.Array.data[1]
+      value: 
+      objectReference: {fileID: 711405199}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bda1cbdccc2441144bc7eaf09e59eec7, type: 3}
+--- !u!1001 &75523774
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 132594, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_Name
+      value: '[SteamVR]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
+--- !u!1 &496918892
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 496918895}
+  - component: {fileID: 496918894}
+  - component: {fileID: 496918893}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &496918893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496918892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &496918894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496918892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &496918895
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496918892}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1696970910}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &711405197
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1696970910}
+    m_Modifications:
+    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Name
+      value: ScoreBoardSideB
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: blueGoal
+      value: 
+      objectReference: {fileID: 1824701090}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
+--- !u!224 &711405198 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 711405197}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &711405199 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 711405197}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1b161d10bc2ee74ea257c9559619dbc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!21 &911775129
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - PixelSnap: 0
+    - _EnableExternalAlpha: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+--- !u!43 &1285964074
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 0000c03f0ad7233c000090bf000000000000803f0000803f0000803f00000000000000000000c0bf0ad7233c000090bf000000000000803f0000803f0000803f0000803f000000000000c0bf0ad7233c0000903f000000000000803f0000803f0000803f00000000000000000000c03f0ad7233c0000903f000000000000803f0000803f0000803f0000803f000000003333d33f0ad7233c3333a3bf000000000000803f0000803f00000000000000000000803f3333d3bf0ad7233c3333a3bf000000000000803f0000803f000000000000803f0000803f3333d3bf0ad7233c3333a33f000000000000803f0000803f00000000000000000000803f3333d33f0ad7233c3333a33f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!1001 &1384528159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1137926388645331768, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_Name
+      value: '[CameraRig]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388645089984, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137926388643162526, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 911775129}
+    - target: {fileID: 1137926388642097178, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1285964074}
+    - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 5659996651250051713, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: offsetY
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: offsetZ
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: zMax
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: zMin
+      value: -8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: xMin
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: xMax
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: yMin
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1718616878126285583, guid: 9ea8269726e18514d89b8730fd18a3dc,
+        type: 3}
+      propertyPath: yMax
+      value: 3.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9ea8269726e18514d89b8730fd18a3dc, type: 3}
+--- !u!1 &1606914381
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1606914383}
+  - component: {fileID: 1606914382}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1606914382
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1606914381}
+  m_Enabled: 1
+  serializedVersion: 9
+  m_Type: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 2
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1606914383
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1606914381}
+  m_LocalRotation: {x: 0.1464466, y: -0.8535535, z: 0.35355338, w: 0.35355338}
+  m_LocalPosition: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 45, y: -135, z: 0}
+--- !u!1 &1696970909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1696970910}
+  m_Layer: 0
+  m_Name: Room UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1696970910
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696970909}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 496918895}
+  - {fileID: 711405198}
+  - {fileID: 1777842403}
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1705863725
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2333401913653627724, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_Name
+      value: BallManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333401913653627726, guid: f4aa22a2ecab817469441efa671b73cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f4aa22a2ecab817469441efa671b73cf, type: 3}
+--- !u!1001 &1777842402
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1696970910}
+    m_Modifications:
+    - target: {fileID: 8870368026426101063, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Name
+      value: ScoreBoardSideA
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+        type: 3}
+      propertyPath: blueGoal
+      value: 
+      objectReference: {fileID: 1824701090}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dffd2011fddadf44bb85284de874e4dd, type: 3}
+--- !u!224 &1777842403 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101059, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1777842402}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1777842404 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8870368026426101056, guid: dffd2011fddadf44bb85284de874e4dd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1777842402}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1b161d10bc2ee74ea257c9559619dbc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1824701090 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2550220586530560703, guid: 9ea8269726e18514d89b8730fd18a3dc,
+    type: 3}
+  m_PrefabInstance: {fileID: 1384528159}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1965531663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1965531665}
+  - component: {fileID: 1965531664}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1965531664
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965531663}
+  m_Enabled: 1
+  serializedVersion: 9
+  m_Type: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 2
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1965531665
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965531663}
+  m_LocalRotation: {x: 0.35355338, y: 0.35355338, z: -0.1464466, w: 0.8535535}
+  m_LocalPosition: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 45, y: 45, z: 0}
+--- !u!1 &2053826535
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2053826538}
+  - component: {fileID: 2053826537}
+  m_Layer: 0
+  m_Name: DevCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &2053826537
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2053826535}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 1
+  m_TargetEye: 0
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2053826538
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2053826535}
+  m_LocalRotation: {x: 0, y: 0.9961947, z: -0.08715578, w: 0}
+  m_LocalPosition: {x: 0.0546875, y: 1.53, z: 2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 10, y: 180, z: 0}
+--- !u!1001 &832769044066454633
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5029571035674930237, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_Name
+      value: Room
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 832769045619086589, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 832769045619086586, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_AreaSize.y
+      value: 10.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 832769045720853707, guid: d25f58688cef9f547a46901d73b41a04,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d25f58688cef9f547a46901d73b41a04, type: 3}

--- a/Assets/Scenes/ImproveSpawnScene.unity.meta
+++ b/Assets/Scenes/ImproveSpawnScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3c29b60b586af134ca1ff297b0c9f29d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ArmScreen.cs
+++ b/Assets/Scripts/ArmScreen.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ArmScreen : MonoBehaviour {
+    private readonly Color[] colors = new Color[2];
+    private float scaleX, scaleY, scaleZ;
+    private Transform trans;
+    private Text text;
+    private RawImage image;
+    [SerializeField]
+    private Camera cam = null;
+    // Start is called before the first frame update
+    void Start() {
+        text = GetComponentInChildren<Text>();
+        image = GetComponent<RawImage>();
+        trans = GetComponent<Transform>();
+        scaleX = trans.localScale.x;
+        scaleY = trans.localScale.y;
+        scaleZ = trans.localScale.z;
+    }
+
+    // Update is called once per frame
+    void Update() {
+        if (Vector3.Dot(transform.right, cam.transform.up) > 0) {
+            trans.localScale = new Vector3(-scaleX, -scaleY, scaleZ);
+        } else {
+            trans.localScale = new Vector3(scaleX, scaleY, scaleZ);
+        }
+        text.text = "Balls: " + BallManager.Instance.PlayerBallQueues[0].Count().ToString();
+        float a = Vector3.Dot(transform.forward, cam.transform.forward) > 0.5f
+            && !(Mathf.Abs(Vector3.Dot(transform.right, cam.transform.up)) < 0.8f) ? Vector3.Dot(transform.forward, cam.transform.forward) : 0;
+        ChangeTransparency(a);
+    }
+
+    private void ChangeTransparency(float alpha) {
+        Color c = text.color;
+        text.color = new Color(c.r, c.g, c.b, alpha);
+        c = image.color;
+        image.color = new Color(c.r, c.g, c.b, alpha);
+    }
+}

--- a/Assets/Scripts/ArmScreen.cs
+++ b/Assets/Scripts/ArmScreen.cs
@@ -29,7 +29,7 @@ public class ArmScreen : MonoBehaviour {
         } else {
             trans.localScale = new Vector3(scaleX, scaleY, scaleZ);
         }
-        text.text = "Balls: " + BallManager.Instance.PlayerBallQueues[0].Count().ToString();
+        text.text = "Balls: " + BallManager.Instance.playerBallQueues[0].childCount.ToString();
         float a = Vector3.Dot(transform.forward, cam.transform.forward) > 0.5f
             && !(Mathf.Abs(Vector3.Dot(transform.right, cam.transform.up)) < 0.8f) ? Vector3.Dot(transform.forward, cam.transform.forward) : 0;
         ChangeTransparency(a);

--- a/Assets/Scripts/ArmScreen.cs.meta
+++ b/Assets/Scripts/ArmScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71fde0d6d64042f4ebe71b1d232e1bca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class Ball : MonoBehaviour {
+    public Transform transformToFollow = null;
     private float lastReadTime = 0f;
     private int listPointer = 0;    // use a pointer instead of shifting the array every update
     private List<Collider> boundsInContact;
     private readonly List<Collider>[] boundsLists = new List<Collider>[numFramesToConsider];
     private readonly static int numFramesToConsider = 3;
     private readonly static float boundListUpdateInterval = 0.33f;   // interval to update lists
-
+    
     // Start is called before the first frame update
     void Start() {
         InitLists();
@@ -24,6 +25,15 @@ public class Ball : MonoBehaviour {
 
     // Update is called once per frame
     void Update() {
+        if (transformToFollow != null) {
+            transform.position = transformToFollow.position;
+            transform.rotation = transformToFollow.rotation;
+        } else {
+            if (IsDead()) {
+                InitLists();
+                BallManager.Instance.PutBallInPool(gameObject);
+            }
+        }
         if (Time.time - lastReadTime > boundListUpdateInterval) {
             boundsLists[listPointer] = new List<Collider>(boundsInContact.ToArray());
             listPointer++;

--- a/Assets/Scripts/BallManager.cs
+++ b/Assets/Scripts/BallManager.cs
@@ -16,7 +16,7 @@ public class BallManager : MonoBehaviour {
     // For debugging at the current stage of development. Just give the player 10 balls for a start
     private static readonly int numberOfStartingBalls = 10;
     // To add a new ball to the queue at fixed intervals
-    private static readonly float ballSpawnInterval = 1f;
+    private static readonly float ballSpawnInterval = 20f;
     private IEnumerator spawnCoroutine;
 
     private void Awake() {
@@ -84,6 +84,11 @@ public class BallManager : MonoBehaviour {
 
     // To be called by spawner
     public void DecrementPoolPointer(int numToDecrement = 1) {
-        poolPointer--;
+        poolPointer -= numToDecrement;
+    }
+
+    // To be called by spawner
+    public void IncrementPoolPointer(int numToIncrement = 1) {
+        poolPointer += numToIncrement;
     }
 }

--- a/Assets/Scripts/HandController.cs
+++ b/Assets/Scripts/HandController.cs
@@ -6,8 +6,6 @@ using UnityEngine;
 public class HandController : MonoBehaviour {
     private Tool tool;
     private SpawnerHand spawnerHand;
-    // true if spawnerHand is supposed to be active, false otherwise
-    public bool isSpawning;
 
     // Start is called before the first frame update
     void Start() {
@@ -25,9 +23,8 @@ public class HandController : MonoBehaviour {
 
     public void SwitchToTool() {
         if (spawnerHand.currentBall != null) {
-            spawnerHand.PutBallBackInQueue();
+            spawnerHand.UnspawnBall();
         }
-        isSpawning = false;
         tool.gameObject.SetActive(true);
         spawnerHand.gameObject.SetActive(false);
     }
@@ -39,7 +36,6 @@ public class HandController : MonoBehaviour {
     }
 
     public void SwitchToSpawnerHand() {
-        isSpawning = true;
         tool.gameObject.SetActive(false);
         spawnerHand.gameObject.SetActive(true);
         StartCoroutine(spawnerHand.TrySpawn());

--- a/Assets/Scripts/HandController.cs
+++ b/Assets/Scripts/HandController.cs
@@ -15,7 +15,18 @@ public class HandController : MonoBehaviour {
         spawnerHand = GetComponentInChildren<SpawnerHand>();
     }
 
+    public void Switch() {
+        if (tool.gameObject.activeInHierarchy) {
+            SwitchToSpawnerHand();
+        } else {
+            SwitchToTool();
+        }
+    }
+
     public void SwitchToTool() {
+        if (spawnerHand.currentBall != null) {
+            spawnerHand.PutBallBackInQueue();
+        }
         isSpawning = false;
         tool.gameObject.SetActive(true);
         spawnerHand.gameObject.SetActive(false);
@@ -27,15 +38,10 @@ public class HandController : MonoBehaviour {
         SwitchToTool();
     }
 
-    public void SwitchToSpawnerHand(GameObject existingBall) {
+    public void SwitchToSpawnerHand() {
         isSpawning = true;
         tool.gameObject.SetActive(false);
         spawnerHand.gameObject.SetActive(true);
-        if (existingBall) {
-            spawnerHand.InheritBall(existingBall);
-        } else {
-            // if no existingBall was passed in, try to spawn a new one
-            StartCoroutine(spawnerHand.TrySpawn());
-        }
+        StartCoroutine(spawnerHand.TrySpawn());
     }
 }

--- a/Assets/Scripts/HandController.cs.meta
+++ b/Assets/Scripts/HandController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -90
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Person.cs
+++ b/Assets/Scripts/Person.cs
@@ -9,12 +9,8 @@ public class Person : MonoBehaviour {
     public SteamVR_Action_Boolean trigger = SteamVR_Input.GetAction<SteamVR_Action_Boolean>("InteractUI");
     private HandController leftHandController;
     private HandController rightHandController;
-    private SpawnerHand currentSpawner = null;
     private SteamVR_Behaviour_Pose leftHand;
     private SteamVR_Behaviour_Pose rightHand;
-    [SerializeField]
-    private bool _isSpawning;
-    public bool IsSpawning { get { return _isSpawning; } set { _isSpawning = value; } }
 
     // Start is called before the first frame update
     void Start() {
@@ -33,42 +29,17 @@ public class Person : MonoBehaviour {
         if (GameManager.Instance.isGameEnded) {
             rightHandController.ResetSpawnerStateAndSwitchToTool();
             leftHandController.ResetSpawnerStateAndSwitchToTool();
-            _isSpawning = false;
             if (trigger.GetStateDown(SteamVR_Input_Sources.Any)) {
                 GameManager.Instance.Restart();
             }
         }
 
-        // if balls are available for spawning, spawn
-        if (!GameManager.Instance.isGameEnded && BallManager.Instance.PlayerBallQueues[0].Count > 0) {
-            if (!_isSpawning) {
-                _isSpawning = true;
-                if (isRightHandSpawner) {
-                    rightHandController.SwitchToSpawnerHand(null);
-                    currentSpawner = rightHand.GetComponentInChildren<SpawnerHand>();
-                } else {
-                    leftHandController.SwitchToSpawnerHand(null);
-                    currentSpawner = leftHand.GetComponentInChildren<SpawnerHand>();
-                }
-            }
+        // if grab is pressed, switch between tool and spawn for that hand
+        if (grab.GetStateDown(rightHand.inputSource)) {
+            rightHandController.Switch();
         }
-
-        // if grab is pressed, change spawn hand
-        // TODO: grab should cause the hand that pressed it to change to a spawner
-        // instead of immediately changing a hand to spawner upon a ball in queue
-        if (grab.GetStateDown(SteamVR_Input_Sources.Any)) {
-            isRightHandSpawner = !isRightHandSpawner;
-            if (_isSpawning) {
-                if (isRightHandSpawner) {
-                    rightHandController.SwitchToSpawnerHand(currentSpawner.currentBall);
-                    currentSpawner = rightHand.GetComponentInChildren<SpawnerHand>();
-                    leftHandController.SwitchToTool();
-                } else {
-                    leftHandController.SwitchToSpawnerHand(currentSpawner.currentBall);
-                    currentSpawner = leftHand.GetComponentInChildren<SpawnerHand>();
-                    rightHandController.SwitchToTool();
-                }
-            }
+        if (grab.GetStateDown(leftHand.inputSource)) {
+            leftHandController.Switch();
         }
     }
 }

--- a/Assets/Scripts/SpawnerHand.cs
+++ b/Assets/Scripts/SpawnerHand.cs
@@ -7,10 +7,10 @@ using Valve.VR;
 // be active on the player's hand instead.
 public class SpawnerHand : MonoBehaviour {
     // A queue of balls that this player should throw. The balls are to be added as children to this GameObject but inactive.
-    public Queue<GameObject> ballsToThrow;
-    public SteamVR_Action_Boolean click = SteamVR_Input.GetAction<SteamVR_Action_Boolean>("InteractUI");
-    public float throwingForce = 100;
-    public float spawnDelay = 0.25f;
+    private Queue<GameObject> ballsToThrow;
+    private SteamVR_Action_Boolean click = SteamVR_Input.GetAction<SteamVR_Action_Boolean>("InteractUI");
+    private readonly float throwingForce = 250;
+    private readonly float spawnDelay = 0.25f;
     public GameObject currentBall;
     private HandController handController;
     private Person person;

--- a/Assets/Scripts/SpawnerHand.cs
+++ b/Assets/Scripts/SpawnerHand.cs
@@ -59,16 +59,23 @@ public class SpawnerHand : MonoBehaviour {
         currentBall.SetActive(true);
     }
 
-    // Inherits a ball. Used when switching spawning hand while in spawning mode
-    public void InheritBall(GameObject ball) {
-        currentBall = ball;
-        SetCurrentBallToFollow();
+    public void RestartState() {
+        if (currentBall != null) {
+            UnspawnBall();
+        }
+        ballsToThrow = null;
     }
 
-    public void RestartState() {
-        Destroy(currentBall);
+    public void UnspawnBall() {
+        BallManager.Instance.PutBallInPool(currentBall);
         currentBall = null;
-        ballsToThrow = null;
+    }
+
+    public void PutBallBackInQueue() {
+        ballsToThrow.Enqueue(currentBall);
+        BallManager.Instance.PutBallInPool(currentBall);
+        BallManager.Instance.IncrementPoolPointer();
+        currentBall = null;
     }
 
     public IEnumerator TrySpawn() {
@@ -87,6 +94,5 @@ public class SpawnerHand : MonoBehaviour {
     // To be called when all balls are tossed
     private void FinishThrowing() {
         handController.SwitchToTool();
-        person.IsSpawning = false;
     }
 }


### PR DESCRIPTION
**Description**

- [`94ed048`](https://github.com/VRFYP2019/Not-Dodgeball/pull/18/commits/94ed0487f5a91e83cd36cae3ea76de964fa251d1) adds a screen to the arm that is only visible when the player is looking more or less directly at it with the left arm rotated to face the screen at the camera.
![bothhandsscreen](https://user-images.githubusercontent.com/28438978/64981026-bfe7d080-d8ed-11e9-85c6-99cd62c1e9f4.gif)

- [`f04ee3e`](https://github.com/VRFYP2019/Not-Dodgeball/pull/18/commits/f04ee3e215b741452a0a3133efe52cec32322f21) allows both hands to switch between spawn and tool at any time.
![bothhandsspawn](https://user-images.githubusercontent.com/28438978/64945102-745c0500-d8a2-11e9-84e3-b595a88d7041.gif)

- [`754bb27`](https://github.com/VRFYP2019/Not-Dodgeball/pull/18/commits/754bb27e1bdb48b6f68709b55cd1dda7290319b9) increases throwing force (and also fix some variable scoping).
![throwfar](https://user-images.githubusercontent.com/28438978/64945154-8f2e7980-d8a2-11e9-868b-4f5bbe42c889.gif)

- [`f649001`](https://github.com/VRFYP2019/Not-Dodgeball/pull/18/commits/f6490013265e0007e36b51f8ce07b988db423fa7) fixes the spawning logic to allow spawning on both hands, and also display the correct number on the arm screens

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
Touched `CameraRig.prefab`

**Test Plan**
Checkout `ImproveSpawnScene` and test these