### PR TITLE
Improve ball deaths

### DIFF
--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -3,16 +3,64 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class Ball : MonoBehaviour {
-    private Rigidbody rb;
+    private float lastReadTime = 0f;
+    private int listPointer = 0;    // use a pointer instead of shifting the array every update
+    private List<Collider> boundsInContact;
+    private readonly List<Collider>[] boundsLists = new List<Collider>[numFramesToConsider];
+    private readonly static int numFramesToConsider = 3;
+    private readonly static float boundListUpdateInterval = 0.33f;   // interval to update lists
+
     // Start is called before the first frame update
     void Start() {
-        rb = GetComponent<Rigidbody>();
+        InitLists();
+    }
+
+    private void InitLists() {
+        for (int i = 0; i < numFramesToConsider; i++) {
+            boundsLists[i] = new List<Collider>();
+        }
+        boundsInContact = new List<Collider>();
     }
 
     // Update is called once per frame
     void Update() {
-        if (rb.IsSleeping()) {
+        if (Time.time - lastReadTime > boundListUpdateInterval) {
+            boundsLists[listPointer] = new List<Collider>(boundsInContact.ToArray());
+            listPointer++;
+            listPointer %= numFramesToConsider;
+            lastReadTime = Time.time;
+        }
+        if (IsDead()) {
+            InitLists();
             BallManager.Instance.PutBallInPool(gameObject);
         }
+    }
+
+    private void OnCollisionEnter(Collision collision) {
+        if (collision.collider.gameObject.layer == LayerMask.NameToLayer("Bounds")) {
+            boundsInContact.Add(collision.collider);
+        }
+    }
+
+    private void OnCollisionExit(Collision collision) {
+        if (collision.collider.gameObject.layer == LayerMask.NameToLayer("Bounds")) {
+            boundsInContact.Remove(collision.collider);
+        }
+    }
+
+    private bool IsDead() {
+        foreach (Collider c in boundsLists[0]) {
+            bool isColliderInEveryList = true;
+            for (int i = 1; i < numFramesToConsider; i++) {
+                if (!boundsLists[i].Contains(c)) {
+                    isColliderInEveryList = false;
+                    break;
+                }
+            }
+            if (isColliderInEveryList) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
**Description**
Use lists of bounds that's in contact with the ball, updated in intervals. This method will kill rolling balls 
![rolldeath](https://user-images.githubusercontent.com/28438978/64960954-ff4ef680-d8c6-11e9-8690-ff8a30379b79.gif)
and also balls that somehow keep moving along the walls (a bug we should look into next time) 
![walldeath](https://user-images.githubusercontent.com/28438978/64960983-1261c680-d8c7-11e9-9b42-e09e12be55dc.gif)

@lyhvictoria

**Impact**
- [x] Minor

**Risks**
- This implementation may hide the bug of balls not bouncing away from walls.
- The code here will conflict with [`dadb138`](https://github.com/VRFYP2019/Not-Dodgeball/commit/dadb1386ed735bb6222ac8428dd42eed4459fadd) in #18 but this code should be used over that.

**Test Plan**
Smack dem balls and see if they die when they should be dying