### PR TITLE
Cure Parkinson's

### DIFF
--- a/ProjectSettings/TimeManager.asset
+++ b/ProjectSettings/TimeManager.asset
@@ -3,7 +3,7 @@
 --- !u!5 &1
 TimeManager:
   m_ObjectHideFlags: 0
-  Fixed Timestep: 0.02
+  Fixed Timestep: 0.01388889
   Maximum Allowed Timestep: 0.33333334
   m_TimeScale: 1
   Maximum Particle Timestep: 0.03


### PR DESCRIPTION
**Description**
Fixes #31 by changing the physics fixed timestep to match the refresh rate of the Quest (72fps). Thanks [reddit](https://www.reddit.com/r/Unity3D/comments/c0vlmf/oculus_quest_jittery_movement_objects/)

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
Hopefully this frame rate won't cause Parkinson's in Vive players?