### PR TITLE
Fix ground level

### DIFF
--- a/Assets/Prefabs/Resources/OVRCameraRig.prefab
+++ b/Assets/Prefabs/Resources/OVRCameraRig.prefab
@@ -1022,7 +1022,7 @@ MonoBehaviour:
   virtualGreenScreenApplyDepthCulling: 0
   virtualGreenScreenDepthTolerance: 0.2
   mrcActivationMode: 0
-  _trackingOriginType: 0
+  _trackingOriginType: 1
   usePositionTracking: 1
   useRotationTracking: 1
   useIPDInPositionTracking: 1

--- a/Assets/Scripts/PlayerLoader.cs
+++ b/Assets/Scripts/PlayerLoader.cs
@@ -17,10 +17,9 @@ public class PlayerLoader : MonoBehaviour {
     void Start() {
         // TODO: differentiate which is connected
         GameObject humanPrefab = OculusPrefab;
-        Vector3 oculusOffset = new Vector3(0, 1.0f, 0); // because y=0 will put you underground
         if (PhotonNetwork.IsConnected) {
             if (PhotonNetwork.LocalPlayer.ActorNumber == 1) {
-                player1 = PhotonNetwork.Instantiate(humanPrefab.name, player1SpawnPoint.position + oculusOffset, player1SpawnPoint.rotation);
+                player1 = PhotonNetwork.Instantiate(humanPrefab.name, player1SpawnPoint.position, player1SpawnPoint.rotation);
                 GameObject offScreenUI1 = Instantiate(OffScreenUIPrefab, OffScreenUIPrefab.transform.position, OffScreenUIPrefab.transform.rotation);
                 offScreenUI1.GetComponent<WallIndicator>().playerLocation = player1.GetComponentInChildren<Camera>(true).transform;
                 offScreenUI1.GetComponent<Canvas>().worldCamera = player1.GetComponentInChildren<Camera>();
@@ -37,7 +36,7 @@ public class PlayerLoader : MonoBehaviour {
             GameObject ballManager = PhotonNetwork.Instantiate(BallManagerPrefab.name, Vector3.zero, Quaternion.identity);
             ballManager.name = "BallManager " + PhotonNetwork.LocalPlayer.ActorNumber;
         } else {
-            player1 = Instantiate(humanPrefab, player1SpawnPoint.position + oculusOffset, player1SpawnPoint.rotation);
+            player1 = Instantiate(humanPrefab, player1SpawnPoint.position, player1SpawnPoint.rotation);
             GameObject offScreenUI1 = Instantiate(OffScreenUIPrefab, OffScreenUIPrefab.transform.position, OffScreenUIPrefab.transform.rotation);
             offScreenUI1.GetComponent<WallIndicator>().playerLocation = player1.GetComponentInChildren<Camera>(true).transform;
             offScreenUI1.GetComponent<Canvas>().worldCamera = player1.GetComponentInChildren<Camera>();


### PR DESCRIPTION
**Description**
Previously some arbitrary offset was used to not bury Oculus Quest users in the ground. Turns out there was a simple enum in the `OVR Manager` used in the `OVRCameraRig` prefab.
![image](https://user-images.githubusercontent.com/28438978/66336387-8b58b900-e96f-11e9-8b9a-b3022dd82a05.png)
Time to 脚踏实地 again

@lyhvictoria

**Impact**
- [x] Minor