### PR TITLE
Add ball colours

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -46,5 +46,6 @@ MonoBehaviour:
   - PhotonAddScore
   - PhotonResetScores
   - PhotonRestart
+  - PhotonSetPlayerNumber
   DisableAutoOpenWizard: 1
   ShowSettings: 1

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -43,6 +43,7 @@ public class Spawner : MonoBehaviour {
         currentBall.GetComponent<Rigidbody>().isKinematic = true;
         SetCurrentBallToFollow();
         currentBall.GetComponent<Ball>().SetState(true);
+        currentBall.GetComponent<Ball>().SetPlayerNumber(GetComponentInParent<Player>().playerNumber);
     }
 
     public void RestartState() {

--- a/Assets/Scripts/Utils.cs
+++ b/Assets/Scripts/Utils.cs
@@ -12,4 +12,7 @@ public static class Utils {
         HUMAN,
         BOT
     }
+
+    public static Color blue = new Color(0, 0.5f, 1);
+    public static Color orange = new Color(0.937f, 0.447f, 0.0823f);
 }


### PR DESCRIPTION
**Description**
Player number as well as colour are set when a ball is put in a spawner. Blue for player 1 and orange for player 2
![com VRFYP2019 Not_Dodgeball-20191009-184907](https://user-images.githubusercontent.com/28438978/66475967-02ed2c00-eac7-11e9-86b7-6dab0a50e5c2.jpg)
![com VRFYP2019 Not_Dodgeball-20191009-185057](https://user-images.githubusercontent.com/28438978/66475972-05e81c80-eac7-11e9-99e9-a33341960576.jpg)

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
Not 100% sure it would show properly on both players' screens in 2 player mode but should be fine. 

**Test Plan**
Throw some balls