### PR TITLE
Goal no longer scores point for own goals

### DIFF
--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -180,6 +180,10 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
         }
     }
 
+    public Utils.PlayerNumber GetPlayerNumber() {
+        return playerNumber;
+    }
+
     private void UpdateColor() {
         mat.color = playerNumber == Utils.PlayerNumber.ONE ? Utils.blue : Utils.orange;
     }

--- a/Assets/Scripts/Goal.cs
+++ b/Assets/Scripts/Goal.cs
@@ -99,11 +99,22 @@ public class Goal : MonoBehaviour {
 
     void OnTriggerEnter(Collider col) {
         if (col.gameObject.layer == LayerMask.NameToLayer("Ball")) {
-            ScoreManager.Instance.AddScoreToOpponent(playerNumber, 1);
-            BallManager.LocalInstance.PutBallInPool(col.gameObject);
-            SwitchGoalState();
+            // Prevent own goal
+            if (col.gameObject.GetComponent<Ball>().GetPlayerNumber() != playerNumber) {
+                ScoreManager.Instance.AddScoreToOpponent(playerNumber, 1);
+                BallManager.LocalInstance.PutBallInPool(col.gameObject);
+                SwitchGoalState();
+            }
         }
     }
+
+    // TODO: KIV on how to deal with collision for own goal
+    // 1) Ball bounce out 2) Ball ignores collision 3) Put ball in pool
+    /*void OnCollisionEnter(Collision col) {
+      if (col.gameObject.GetComponent<Ball>().GetPlayerNumber() == playerNumber) {
+          Physics.IgnoreCollision(col.gameObject.GetComponent<Collider>(), this.GetComponent<Collider>());
+      }
+    } */
 
     private void SwitchGoalState() {
         goalState = (goalState == GoalState.FOLLOWING) ? GoalState.STATIONARY : GoalState.TRANSITION;


### PR DESCRIPTION
**Description**
Player's goal trigger collider will now ignore their own balls and scores will not count for own goals.
Currently, the ball will just bounce out of the goal.  

@khooroko
@lyhvictoria

**Impact**
If impact is minor, no need for the reviewer to check out the branch to test locally before approval
- [ ] Major
- [x] Medium
- [ ] Minor

**Risks**
Future play testing will be required to see how to best deal with own goal balls with respect to the goal colliders. 