### PR TITLE
Fix loading main scene

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -96,7 +96,8 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
     m_ExportTrainingData: 0
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 112000000, guid: e40f7bf9c721a6f49a2eae16fe81ffdc,
+    type: 2}
   m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
@@ -554,16 +555,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: FollowersParent
       objectReference: {fileID: 0}
-    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
-        type: 3}
-      propertyPath: ObservedComponents.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
-        type: 3}
-      propertyPath: viewIdField
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5356393244840461066, guid: f0ba31bdda24ba447b07d3c87d113e5c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -618,6 +609,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
+        type: 3}
+      propertyPath: ObservedComponents.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
+        type: 3}
+      propertyPath: viewIdField
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f0ba31bdda24ba447b07d3c87d113e5c, type: 3}
@@ -992,16 +993,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: GameManager
       objectReference: {fileID: 0}
-    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
-        type: 3}
-      propertyPath: ObservedComponents.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
-        type: 3}
-      propertyPath: viewIdField
-      value: 3
-      objectReference: {fileID: 0}
     - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1056,6 +1047,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: ObservedComponents.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: viewIdField
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bda1cbdccc2441144bc7eaf09e59eec7, type: 3}

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -145,6 +145,9 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
     }
 
     public void SetState(bool active) {
+        if (!hasBeenInit) {
+            Init();
+        }
         if (PhotonNetwork.IsConnected) {
             pView.RPC("PhotonSetState", RpcTarget.All, active);
         } else {

--- a/Assets/Scripts/Human.cs
+++ b/Assets/Scripts/Human.cs
@@ -23,8 +23,12 @@ public class Human : Player {
             foreach (GameObject g in localObjects) {
                 g.SetActive(false);
             }
-            GetComponentInChildren<Camera>().enabled = false;
-            GetComponentInChildren<AudioListener>().enabled = false;
+            foreach (Camera cam in GetComponentsInChildren<Camera>()) {
+                cam.enabled = false;
+            }
+            foreach (AudioListener al in GetComponentsInChildren<AudioListener>()) {
+                GetComponentInChildren<AudioListener>().enabled = false;
+            }
             this.enabled = false;
         } else {
             base.Start();

--- a/Assets/Scripts/PlayerLoader.cs
+++ b/Assets/Scripts/PlayerLoader.cs
@@ -15,8 +15,8 @@ public class PlayerLoader : MonoBehaviour {
     private GameObject player1, player2;
     // Start is called before the first frame update
     void Start() {
-        // TODO: differentiate which is connected
-        GameObject humanPrefab = OculusPrefab;
+        // TODO: add a new prefab for editor
+        GameObject humanPrefab = GameManager.Instance.isOculusQuest ? OculusPrefab : OpenVRPrefab;
         if (PhotonNetwork.IsConnected) {
             if (PhotonNetwork.LocalPlayer.ActorNumber == 1) {
                 player1 = PhotonNetwork.Instantiate(humanPrefab.name, player1SpawnPoint.position, player1SpawnPoint.rotation);


### PR DESCRIPTION
**Description**
Previously after migrating to Oculus, the pooled balls dump out Null Reference Exceptions and completely break the game if loaded from lobby. This is because the photonView of those balls have not been initialized.

Also everything went black again so this PR puts it back. 
Maybe mobile builds will unlink the lightmap data from one scene each time we link it to another?

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
This is more of a hotfix, will test more things after implementing an editor prefab to ease local debugging

**Test Plan**
Load the game from the lobby, should be playable