### PR TITLE
Improve smoothness

### DIFF
--- a/Assets/Prefabs/PlayerLoader.prefab
+++ b/Assets/Prefabs/PlayerLoader.prefab
@@ -111,6 +111,8 @@ MonoBehaviour:
     type: 3}
   EditorPlayerPrefab: {fileID: 1721402358905198656, guid: 069c61a9914ee0f44a932eb1a41ba6c7,
     type: 3}
+  DevCamPrefab: {fileID: 1547788476506631281, guid: 2f9b512cef5b3e546bf8c8e7788f4fa2,
+    type: 3}
   BotPrefab: {fileID: 6737888576237609523, guid: 6d6821ea1c3bf344db771f9fd2266cce,
     type: 3}
   OffScreenUIPrefab: {fileID: 3701012152876681771, guid: cd2ee31511a22cc43b98286fd8b591f4,

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -121,80 +121,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &106695367
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 106695369}
-  - component: {fileID: 106695368}
-  m_Layer: 0
-  m_Name: DevCam
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!20 &106695368
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 106695367}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 1
-  m_TargetEye: 0
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &106695369
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 106695367}
-  m_LocalRotation: {x: 0, y: 0.9961947, z: -0.08715578, w: 0}
-  m_LocalPosition: {x: 0.0546875, y: 1.53, z: 2.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 10, y: 180, z: 0}
 --- !u!1 &193222540
 GameObject:
   m_ObjectHideFlags: 0
@@ -284,7 +210,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 45, y: -135, z: 0}
 --- !u!1001 &235627300
 PrefabInstance:
@@ -476,7 +402,7 @@ PrefabInstance:
     - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8212153540449165712, guid: d25f58688cef9f547a46901d73b41a04,
         type: 3}
@@ -564,7 +490,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &490024653
 GameObject:
@@ -597,7 +523,7 @@ Transform:
   - {fileID: 1239825380}
   - {fileID: 235627301}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &845918788
 PrefabInstance:
@@ -610,16 +536,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: FollowersParent
-      objectReference: {fileID: 0}
-    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
-        type: 3}
-      propertyPath: ObservedComponents.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
-        type: 3}
-      propertyPath: viewIdField
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5356393244840461066, guid: f0ba31bdda24ba447b07d3c87d113e5c,
         type: 3}
@@ -659,7 +575,7 @@ PrefabInstance:
     - target: {fileID: 5356393244840461066, guid: f0ba31bdda24ba447b07d3c87d113e5c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5356393244840461066, guid: f0ba31bdda24ba447b07d3c87d113e5c,
         type: 3}
@@ -675,6 +591,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
+        type: 3}
+      propertyPath: ObservedComponents.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -5993483263316044797, guid: f0ba31bdda24ba447b07d3c87d113e5c,
+        type: 3}
+      propertyPath: viewIdField
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f0ba31bdda24ba447b07d3c87d113e5c, type: 3}
@@ -978,7 +904,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 45, y: 45, z: 0}
 --- !u!1001 &1653081269
 PrefabInstance:
@@ -1021,7 +947,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 458990, guid: 4f35fa249b5008c44ac2998be6f82d4d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1048,16 +974,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GameManager
-      objectReference: {fileID: 0}
-    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
-        type: 3}
-      propertyPath: ObservedComponents.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
-        type: 3}
-      propertyPath: viewIdField
-      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
         type: 3}
@@ -1097,7 +1013,7 @@ PrefabInstance:
     - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 4165734954415435639, guid: bda1cbdccc2441144bc7eaf09e59eec7,
         type: 3}
@@ -1113,6 +1029,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: ObservedComponents.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -5876371638361692314, guid: bda1cbdccc2441144bc7eaf09e59eec7,
+        type: 3}
+      propertyPath: viewIdField
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bda1cbdccc2441144bc7eaf09e59eec7, type: 3}
@@ -1171,7 +1097,7 @@ PrefabInstance:
     - target: {fileID: 4013251129613109251, guid: ed6d1967c31f4e04b80ac93a62b021f4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 4013251129613109251, guid: ed6d1967c31f4e04b80ac93a62b021f4,
         type: 3}
@@ -1240,7 +1166,7 @@ PrefabInstance:
     - target: {fileID: 7698177593181359282, guid: 03543cf34491c6244b5a7e7947aa92c6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7698177593181359282, guid: 03543cf34491c6244b5a7e7947aa92c6,
         type: 3}

--- a/Assets/Scripts/PlayerLoader.cs
+++ b/Assets/Scripts/PlayerLoader.cs
@@ -8,6 +8,7 @@ public class PlayerLoader : MonoBehaviour {
     public GameObject OpenVRPrefab;
     public GameObject OculusPrefab;
     public GameObject EditorPlayerPrefab;
+    public GameObject DevCamPrefab;
     public GameObject BotPrefab;
     public GameObject OffScreenUIPrefab;
     public GameObject BallManagerPrefab;
@@ -53,6 +54,9 @@ public class PlayerLoader : MonoBehaviour {
             player2.GetComponent<Player>().playerNumber = Utils.PlayerNumber.TWO;
 
             GameObject ballManager = Instantiate(BallManagerPrefab);
+        }
+        if (GameManager.Instance.isEditor) {
+            Instantiate(DevCamPrefab);
         }
     }
 }


### PR DESCRIPTION
**Description**
Having multiple cameras in the scene makes things look laggy on the Quest. This is especially observable for slow moving hands.
DevCam is now a prefab that will only spawn when played from editor.

@lyhvictoria

**Impact**
- [x] Minor

**Test Plan**
See that there is an improvement in smoothness (though still not perfect) of moving things such as tools and balls from the Quest