### PR TITLE
Change buttons for switching tool

### DIFF
--- a/Assets/Scripts/Human.cs
+++ b/Assets/Scripts/Human.cs
@@ -62,11 +62,11 @@ public class Human : Player {
         }
 
         if (GameManager.Instance.isOculusQuest) {
-            if (OVRInput.GetDown(OVRInput.Button.PrimaryHandTrigger)) {
+            if (OVRInput.GetDown(OVRInput.RawButton.X | OVRInput.RawButton.Y)) {
                 leftHandController.Switch();
             }
 
-            if (OVRInput.GetDown(OVRInput.Button.SecondaryHandTrigger)) {
+            if (OVRInput.GetDown(OVRInput.RawButton.A | OVRInput.RawButton.B)) {
                 rightHandController.Switch();
             }
         } else if (!GameManager.Instance.isEditor) {


### PR DESCRIPTION
**Description**
Grip for Oculus Quest controllers are over-sensitive. Change to A and B for left hand and X and Y for right hand for switching tools.

@lyhvictoria

**Impact**
- [x] Minor

**Test Plan**
Switch around