### PR TITLE
Improve feedback for switching

### DIFF
--- a/Assets/Prefabs/HumanHand.prefab
+++ b/Assets/Prefabs/HumanHand.prefab
@@ -95,7 +95,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7965826471793230937}
-  - component: {fileID: 8147850146262060191}
+  - component: {fileID: 518475807796813900}
   - component: {fileID: 6377588284077882066}
   m_Layer: 0
   m_Name: HumanHand
@@ -121,7 +121,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8147850146262060191
+--- !u!114 &518475807796813900
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -130,9 +130,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1368452946636138963}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d9fae2d871d29f4899c3a3065645bc9, type: 3}
+  m_Script: {fileID: 11500000, guid: 9922fa266f2093a4089ad4e3b0af5d62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  currHandObject: 0
   handSide: 0
 --- !u!114 &6377588284077882066
 MonoBehaviour:

--- a/Assets/Prefabs/Resources/EditorPlayer.prefab
+++ b/Assets/Prefabs/Resources/EditorPlayer.prefab
@@ -142,11 +142,11 @@ MonoBehaviour:
     needsReinit: 0
   localScripts:
   - {fileID: 7577507220119340156}
-  - {fileID: 2901789487449700406}
+  - {fileID: 6802194260313150693}
   - {fileID: 7997838457001972563}
   - {fileID: 2047019986481843565}
   - {fileID: 2829103007000005133}
-  - {fileID: 8470627244425768348}
+  - {fileID: 265346311643070799}
   - {fileID: 3690289779684345593}
   - {fileID: 4729049428830755015}
   - {fileID: 8829995919700205479}
@@ -234,6 +234,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1721402358905198658}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
@@ -303,16 +308,16 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 333068531395387651}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &8470627244425768348 stripped
+--- !u!114 &265346311643070799 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+  m_CorrespondingSourceObject: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
     type: 3}
   m_PrefabInstance: {fileID: 333068531395387651}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d9fae2d871d29f4899c3a3065645bc9, type: 3}
+  m_Script: {fileID: 11500000, guid: 9922fa266f2093a4089ad4e3b0af5d62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &3690289779684345593 stripped
@@ -364,6 +369,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1721402358905198658}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
@@ -433,16 +443,16 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6437826002679133353}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2901789487449700406 stripped
+--- !u!114 &6802194260313150693 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+  m_CorrespondingSourceObject: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
     type: 3}
   m_PrefabInstance: {fileID: 6437826002679133353}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d9fae2d871d29f4899c3a3065645bc9, type: 3}
+  m_Script: {fileID: 11500000, guid: 9922fa266f2093a4089ad4e3b0af5d62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &7997838457001972563 stripped
@@ -494,11 +504,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1721402359657460489}
     m_Modifications:
-    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: m_Name
-      value: GoalPost
-      objectReference: {fileID: 0}
     - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -553,6 +558,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_Name
+      value: GoalPost
       objectReference: {fileID: 0}
     - target: {fileID: 6518231945215148719, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}

--- a/Assets/Prefabs/Resources/OVRPlayer.prefab
+++ b/Assets/Prefabs/Resources/OVRPlayer.prefab
@@ -640,12 +640,12 @@ MonoBehaviour:
     needsReinit: 0
   localScripts:
   - {fileID: 5716603626697485388}
-  - {fileID: 3063319224930982843}
+  - {fileID: 6674366615824283496}
   - {fileID: 220778438965194230}
   - {fileID: 7798023449863762142}
   - {fileID: 2210804959684079328}
   - {fileID: 2703528130772838784}
-  - {fileID: 1706144067803885811}
+  - {fileID: 7029685211702713376}
   - {fileID: 4485080233822652094}
   - {fileID: 5842942661370993558}
   - {fileID: 2558100673691501992}
@@ -750,11 +750,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 71325662272139836}
     m_Modifications:
-    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: m_Name
-      value: GoalPost
-      objectReference: {fileID: 0}
     - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -810,6 +805,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_Name
+      value: GoalPost
+      objectReference: {fileID: 0}
     - target: {fileID: 6518231945215148719, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -825,12 +825,7 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8253398896947689217, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: viewIdField
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 837993900814087325, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    - target: {fileID: 3385298636954653196, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: viewIdField
       value: 0
@@ -840,7 +835,12 @@ PrefabInstance:
       propertyPath: viewIdField
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3385298636954653196, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    - target: {fileID: 8253398896947689217, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: viewIdField
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 837993900814087325, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: viewIdField
       value: 0
@@ -878,15 +878,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5798643184190185188}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
       value: LeftHand
-      objectReference: {fileID: 0}
-    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: vibration.actionPath
-      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 7965826471793230937, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -943,16 +943,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
-      propertyPath: handSide
-      value: 1
+      propertyPath: vibration.actionPath
+      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 7405048378267027422, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: cam
       value: 
       objectReference: {fileID: 71325662270504422}
+    - target: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4c4aaf52cbbb82147ac9b92d3dd72593, type: 3}
 --- !u!1 &5290703336778448631 stripped
@@ -967,16 +972,16 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6598303500989519652}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &3063319224930982843 stripped
+--- !u!114 &6674366615824283496 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+  m_CorrespondingSourceObject: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
     type: 3}
   m_PrefabInstance: {fileID: 6598303500989519652}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5290703336778448631}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d9fae2d871d29f4899c3a3065645bc9, type: 3}
+  m_Script: {fileID: 11500000, guid: 9922fa266f2093a4089ad4e3b0af5d62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &220778438965194230 stripped
@@ -1040,15 +1045,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5798643184190185188}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
       value: RightHand
-      objectReference: {fileID: 0}
-    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: vibration.actionPath
-      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 7965826471793230937, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1105,6 +1110,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: vibration.actionPath
+      value: /actions/default/out/Haptic
+      objectReference: {fileID: 0}
     - target: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: handSide
@@ -1124,16 +1134,16 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7403788545556986988}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1706144067803885811 stripped
+--- !u!114 &7029685211702713376 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+  m_CorrespondingSourceObject: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
     type: 3}
   m_PrefabInstance: {fileID: 7403788545556986988}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8377314061004756415}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d9fae2d871d29f4899c3a3065645bc9, type: 3}
+  m_Script: {fileID: 11500000, guid: 9922fa266f2093a4089ad4e3b0af5d62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &5842942661370993558 stripped

--- a/Assets/Prefabs/Resources/SteamVRPlayer.prefab
+++ b/Assets/Prefabs/Resources/SteamVRPlayer.prefab
@@ -369,12 +369,12 @@ MonoBehaviour:
   - {fileID: 2118341066931277675}
   - {fileID: 2118341067558500295}
   - {fileID: 6046311033002593308}
-  - {fileID: 3337545636297290576}
+  - {fileID: 0}
   - {fileID: 559040478466573597}
   - {fileID: 7559966574011930677}
   - {fileID: 1908431049556313611}
   - {fileID: 2402279020973048171}
-  - {fileID: 2611293871931052781}
+  - {fileID: 0}
   - {fileID: 985841608235541664}
   - {fileID: 7099379906499557768}
   - {fileID: 1157546118739666870}
@@ -463,11 +463,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2118341067245113424}
     m_Modifications:
-    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: m_Name
-      value: GoalPost
-      objectReference: {fileID: 0}
     - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -523,6 +518,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_Name
+      value: GoalPost
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 68133f0ebc3140b419b63fd9ee0e7709, type: 3}
 --- !u!1 &7445922657630590380 stripped
@@ -556,6 +556,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2118341067558500290}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
@@ -629,18 +634,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6138361732013907570}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2611293871931052781 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-    type: 3}
-  m_PrefabInstance: {fileID: 6138361732013907570}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d9fae2d871d29f4899c3a3065645bc9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &985841608235541664 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
@@ -702,6 +695,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2118341066931277686}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
@@ -775,18 +773,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6864509044891533263}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &3337545636297290576 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-    type: 3}
-  m_PrefabInstance: {fileID: 6864509044891533263}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d9fae2d871d29f4899c3a3065645bc9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &559040478466573597 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,

--- a/Assets/Scripts/HandController.cs
+++ b/Assets/Scripts/HandController.cs
@@ -5,20 +5,15 @@ using Utils;
 
 // Controls what the hand is doing, i.e. spawning or smacking
 public class HandController : MonoBehaviour {
-    [Tooltip("Left or right. Only required for OVR.")]
-    public HandSide handSide;
     private Tool tool;
     private Spawner spawnerHand;
+    public HandObject currHandObject;
     bool hasBeenInit = false;
 
     // Start is called before the first frame update
-    void Start() {
+    protected virtual void Start() {
         if (!hasBeenInit) {
             Init();
-        }
-        if (GameManager.Instance.playerPlatform == PlayerPlatform.OCULUS
-            && handSide == HandSide.UNSPECIFIED) {
-            Debug.LogWarning("Hand side not selected.");
         }
     }
 
@@ -37,6 +32,7 @@ public class HandController : MonoBehaviour {
     }
 
     public void SwitchToTool() {
+        currHandObject = HandObject.TOOL;
         if (!hasBeenInit) {
             Init();
         }
@@ -55,6 +51,7 @@ public class HandController : MonoBehaviour {
     }
 
     public void SwitchToSpawnerHand() {
+        currHandObject = HandObject.SPAWNER;
         tool.SetFollowerActive(false);
         tool.SetState(false);
         spawnerHand.SetState(true);

--- a/Assets/Scripts/HandControllerHuman.cs
+++ b/Assets/Scripts/HandControllerHuman.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Utils;
+
+public class HandControllerHuman : HandController {
+    [Tooltip("Left or right. Only required for OVR.")]
+    public HandSide handSide;
+    private HapticFeedback hapticFeedback;
+    // Start is called before the first frame update
+    protected override void Start() {
+        base.Start();
+        if (GameManager.Instance.playerPlatform == PlayerPlatform.OCULUS
+            && handSide == HandSide.UNSPECIFIED) {
+            Debug.LogWarning("Hand side not selected.");
+        }
+        if (!(GameManager.Instance.playerPlatform == PlayerPlatform.EDITOR)) {
+            hapticFeedback = GetComponent<HapticFeedback>();
+        }
+    }
+
+    public void TriggerHapticFeedback(float duration, float frequency, float amplitude) {
+        if (!(GameManager.Instance.playerPlatform == PlayerPlatform.EDITOR)) {
+            hapticFeedback.Vibrate(duration, frequency, amplitude);
+        }
+    }
+}

--- a/Assets/Scripts/HandControllerHuman.cs.meta
+++ b/Assets/Scripts/HandControllerHuman.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9922fa266f2093a4089ad4e3b0af5d62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/HapticFeedback.cs
+++ b/Assets/Scripts/HapticFeedback.cs
@@ -13,7 +13,7 @@ public class HapticFeedback : MonoBehaviour {
         if (GameManager.Instance.playerPlatform == PlayerPlatform.STEAMVR) {
             trackedObj = GetComponentInParent<SteamVR_Behaviour_Pose>().inputSource;
         }
-        HandSide handSide = GetComponent<HandController>().handSide;
+        HandSide handSide = GetComponent<HandControllerHuman>().handSide;
         if (handSide == HandSide.LEFT) {
             controllerMask = OVRInput.Controller.LTouch;
         } else if (handSide == HandSide.RIGHT) {

--- a/Assets/Scripts/Human.cs
+++ b/Assets/Scripts/Human.cs
@@ -67,18 +67,32 @@ public class Human : Player {
 
         if (GameManager.Instance.playerPlatform == PlayerPlatform.OCULUS) {
             if (OVRInput.GetDown(OVRInput.RawButton.X | OVRInput.RawButton.Y)) {
-                leftHandController.Switch();
+                SwitchHandObject(HandSide.LEFT);
             }
 
             if (OVRInput.GetDown(OVRInput.RawButton.A | OVRInput.RawButton.B)) {
-                rightHandController.Switch();
+                SwitchHandObject(HandSide.RIGHT);
             }
         } else if (GameManager.Instance.playerPlatform == PlayerPlatform.STEAMVR) {
-            if (grab.GetStateDown(rightHand.inputSource)) {
-                rightHandController.Switch();
-            }
             if (grab.GetStateDown(leftHand.inputSource)) {
-                leftHandController.Switch();
+                SwitchHandObject(HandSide.LEFT);
+            }
+            if (grab.GetStateDown(rightHand.inputSource)) {
+                SwitchHandObject(HandSide.RIGHT);
+            }
+        }
+    }
+
+    protected override void SwitchHandObject(HandSide handSide) {
+        base.SwitchHandObject(handSide);
+        // if player is trying to switch to spawner when no balls left,
+        // trigger feedback to let them know it's not allowed
+        if (BallManager.LocalInstance.playerBallQueue.childCount == 0) {
+            if (handSide == HandSide.LEFT && leftHandController.currHandObject == HandObject.TOOL) {
+                ((HandControllerHuman)leftHandController).TriggerHapticFeedback(0.1f, 100, 30);
+            }
+            if (handSide == HandSide.RIGHT && rightHandController.currHandObject == HandObject.TOOL) {
+                ((HandControllerHuman)rightHandController).TriggerHapticFeedback(0.1f, 100, 30);
             }
         }
     }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -41,4 +41,32 @@ public class Player : MonoBehaviourPunCallbacks {
             Player_SetPlayerNumber((int)playerNumber);
         }
     }
+
+    protected virtual void SwitchHandObject(HandSide handSide) {
+        if (handSide == HandSide.LEFT) {
+            if (leftHandController.currHandObject == HandObject.TOOL
+                && BallManager.LocalInstance.playerBallQueue.childCount == 1
+                && rightHandController.currHandObject == HandObject.SPAWNER
+                ) {
+                // If, when trying to switch this hand to spawner, and there is
+                // only 1 ball left and it is being held by another hand,
+                // take it out of that hand
+                rightHandController.ResetSpawnerStateAndSwitchToTool();
+            }
+            // Only switch between spawner and tool if there is at least 1 ball in queue
+            if (BallManager.LocalInstance.playerBallQueue.childCount > 0) {
+                leftHandController.Switch();
+            }
+        } else if (handSide == HandSide.RIGHT) {
+            if (rightHandController.currHandObject == HandObject.TOOL
+                && BallManager.LocalInstance.playerBallQueue.childCount == 1
+                && leftHandController.currHandObject == HandObject.SPAWNER) {
+                leftHandController.ResetSpawnerStateAndSwitchToTool();
+            }
+            // Only switch between spawner and tool if there is at least 1 ball in queue
+            if (BallManager.LocalInstance.playerBallQueue.childCount > 0) {
+                rightHandController.Switch();
+            }
+        }
+    }
 }

--- a/Assets/Scripts/SpawnerHumanController.cs
+++ b/Assets/Scripts/SpawnerHumanController.cs
@@ -17,7 +17,7 @@ public class SpawnerHumanController : MonoBehaviour {
             handPose = GetComponentInParent<SteamVR_Behaviour_Pose>();
         }
         spawner = GetComponent<Spawner>();
-        handSide = GetComponentInParent<HandController>().handSide;
+        handSide = GetComponentInParent<HandControllerHuman>().handSide;
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/ToolHuman.cs
+++ b/Assets/Scripts/ToolHuman.cs
@@ -1,23 +1,16 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using Utils;
 
 public class ToolHuman : Tool {
-    private HapticFeedback hapticFeedback;
+    private HandControllerHuman handControllerHuman;
 
-    // Start is called before the first frame update
-    protected override void Start() {
-        base.Start();
-        if (!(GameManager.Instance.playerPlatform == PlayerPlatform.EDITOR)) {
-            hapticFeedback = GetComponentInParent<HapticFeedback>();
-        }
+    private void Awake() {
+        handControllerHuman = GetComponentInParent<HandControllerHuman>();
     }
 
     public void TriggerHapticFeedback(float duration, float frequency, float amplitude) {
-        if (!(GameManager.Instance.playerPlatform == PlayerPlatform.EDITOR)) {
-            hapticFeedback.Vibrate(duration, frequency, amplitude);
-        }
+        handControllerHuman.TriggerHapticFeedback(duration, frequency, amplitude);
     }
 
     protected override void SpawnToolFollower() {

--- a/Assets/Scripts/Utils.cs
+++ b/Assets/Scripts/Utils.cs
@@ -23,6 +23,10 @@ namespace Utils {
         LEFT,
         RIGHT
     }
+    public enum HandObject {
+        TOOL,
+        SPAWNER
+    }
 
     public static class Constants {
         public static class Colors {


### PR DESCRIPTION
**Description**

- Switching to spawner when there is 1 ball left, and the ball is on the other hand, causes the other hand to switch back to tool and let this hand switch to spawner and get the ball.
- Trying to switch to spawner when there are no balls left triggers a haptic feedback on the offending hand

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
The structure of the code is modified (`toolHuman` no longer having a reference to `hapticFeedback`, but `humanHandController` has it now instead), and this may have unintended and unforeseen effects

**Test Plan**
Switch around in all cases, for both hands:

- more than 1 ball left
- 1 ball left and in other hand
- 1 ball left and not in other hand
- 0 balls left

and also test other core functionalities