### PR TITLE
Fix dummy bot prefab

### DIFF
--- a/Assets/Prefabs/Resources/DummyBot.prefab
+++ b/Assets/Prefabs/Resources/DummyBot.prefab
@@ -135,7 +135,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fc43ce1aa4ea9594cb9650ba7c59e357, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _toolFollowerPrefab: {fileID: 4644954167196449662, guid: 62243949ae3d56547a16740900d19c29,
+  toolFollowerPrefab: {fileID: 4644954167196449662, guid: 62243949ae3d56547a16740900d19c29,
     type: 3}
 --- !u!1 &1206403453
 GameObject:
@@ -180,7 +180,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fc43ce1aa4ea9594cb9650ba7c59e357, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _toolFollowerPrefab: {fileID: 4644954167196449662, guid: 62243949ae3d56547a16740900d19c29,
+  toolFollowerPrefab: {fileID: 4644954167196449662, guid: 62243949ae3d56547a16740900d19c29,
     type: 3}
 --- !u!1 &1209663953
 GameObject:


### PR DESCRIPTION
**Description**
There was a null reference exception when trying to play single player because `DummyBot` had its tool followers removed from their prefabs at some point.
![image](https://user-images.githubusercontent.com/28438978/72057225-00d67b80-3309-11ea-8010-84c0e4241774.png)
This fixes that

@lyhvictoria

**Impact**
- [x] Minor