### PR TITLE
Add player ready button

### DIFF
--- a/Assets/Prefabs/PlayerEntryListItem.prefab
+++ b/Assets/Prefabs/PlayerEntryListItem.prefab
@@ -33,6 +33,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8136535656846671843}
+  - {fileID: 2462413047450557749}
+  - {fileID: 771318948985357968}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -136,6 +138,187 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PlayerNameText: {fileID: 4214035195907553316}
+  PlayerReadyButton: {fileID: 7284000691832689564}
+  PlayerReadyColor: {r: 0.14640442, g: 0.6603774, b: 0.17322037, a: 1}
+--- !u!1 &3784622889840453184
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2837213070106609349}
+  - component: {fileID: 5954655761672528239}
+  - component: {fileID: 7191577556235748861}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2837213070106609349
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3784622889840453184}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 771318948985357968}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5954655761672528239
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3784622889840453184}
+  m_CullTransparentMesh: 0
+--- !u!114 &7191577556235748861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3784622889840453184}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Ready?
+--- !u!1 &4322236445426046238
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2462413047450557749}
+  - component: {fileID: 2438668829913559136}
+  - component: {fileID: 1207990869993502739}
+  - component: {fileID: 6308058335686905987}
+  m_Layer: 0
+  m_Name: SpaceFiller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2462413047450557749
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4322236445426046238}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 705266896574582078}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2438668829913559136
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4322236445426046238}
+  m_CullTransparentMesh: 0
+--- !u!114 &1207990869993502739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4322236445426046238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!114 &6308058335686905987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4322236445426046238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1679637790, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 0
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &7151704131448057044
 GameObject:
   m_ObjectHideFlags: 0
@@ -147,6 +330,7 @@ GameObject:
   - component: {fileID: 8136535656846671843}
   - component: {fileID: 337345726398309227}
   - component: {fileID: 4214035195907553316}
+  - component: {fileID: 737969694943020271}
   m_Layer: 0
   m_Name: PLayerNameText
   m_TagString: Untagged
@@ -215,3 +399,165 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Player Name
+--- !u!114 &737969694943020271
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7151704131448057044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1679637790, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 0
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &7322806011308462315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 771318948985357968}
+  - component: {fileID: 4747371768944404519}
+  - component: {fileID: 579000567067421221}
+  - component: {fileID: 7284000691832689564}
+  - component: {fileID: 760887856766966964}
+  m_Layer: 0
+  m_Name: PlayerReadyButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &771318948985357968
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322806011308462315}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2837213070106609349}
+  m_Father: {fileID: 705266896574582078}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4747371768944404519
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322806011308462315}
+  m_CullTransparentMesh: 0
+--- !u!114 &579000567067421221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322806011308462315}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!114 &7284000691832689564
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322806011308462315}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 579000567067421221}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &760887856766966964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322806011308462315}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1679637790, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 60
+  m_MinHeight: -1
+  m_PreferredWidth: 75
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 0
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1

--- a/Assets/Prefabs/PlayerEntryListItem.prefab
+++ b/Assets/Prefabs/PlayerEntryListItem.prefab
@@ -218,7 +218,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Ready?
+  m_Text: Ready!
 --- !u!1 &4322236445426046238
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NetworkController.cs
+++ b/Assets/Scripts/NetworkController.cs
@@ -100,7 +100,7 @@ public class NetworkController : MonoBehaviourPunCallbacks {
         }
 
         // Create and add PlayerListEntryPrefabs for every player in the room to scrollview
-        foreach (Photon.Realtime.Player p in PhotonNetwork.PlayerList) {
+        foreach (PhotonPlayer p in PhotonNetwork.PlayerList) {
             GameObject entry = Instantiate(PlayerListEntryPrefab);
             entry.transform.SetParent(RoomInfoContent.transform, false);
             entry.GetComponent<PlayerListEntry>().Initialize(p.ActorNumber, p.NickName);
@@ -151,6 +151,7 @@ public class NetworkController : MonoBehaviourPunCallbacks {
         }
 
         GameObject entry;
+        // Update targetPlayer's ready status for local player
         if (playerListEntries.TryGetValue(targetPlayer.ActorNumber, out entry)) {
             object isPlayerReady;
             if (changedProps.TryGetValue("PLAYER_READY_KEY", out isPlayerReady)) {
@@ -176,7 +177,6 @@ public class NetworkController : MonoBehaviourPunCallbacks {
 
         string roomName = RoomNameInputField.text;
         roomName = (roomName.Equals(string.Empty)) ? "Room " + Random.Range(1000, 10000) : roomName;
-        //RoomOptions options = new RoomOptions {MaxPlayers = 2};
 
         RoomOptions roomOptions = new RoomOptions {};
         PhotonNetwork.JoinOrCreateRoom(roomName, roomOptions, TypedLobby.Default);

--- a/Assets/Scripts/PlayerListEntry.cs
+++ b/Assets/Scripts/PlayerListEntry.cs
@@ -44,7 +44,7 @@ public class PlayerListEntry : MonoBehaviour {
     }
 
     public void SetPlayerReady(bool playerReady) {
-        PlayerReadyButton.GetComponentInChildren<Text>().text = playerReady ? "Ready?" : "Ready!";
+        PlayerReadyButton.GetComponentInChildren<Text>().text = playerReady ? "Not Ready" : "Ready!";
         PlayerNameText.gameObject.GetComponent<Text>().color = playerReady ? PlayerReadyColor : Color.black;
     }
 }

--- a/Assets/Scripts/PlayerListEntry.cs
+++ b/Assets/Scripts/PlayerListEntry.cs
@@ -7,13 +7,44 @@ using ExitGames.Client.Photon;
 using Photon.Pun;
 using Photon.Realtime;
 
+using PhotonHashtable = ExitGames.Client.Photon.Hashtable;
+
 public class PlayerListEntry : MonoBehaviour {
 
     public Text PlayerNameText;
+    public Button PlayerReadyButton;
+    public Color PlayerReadyColor;
+
     private int ownerId;
+    private bool isPlayerReady;
 
     public void Initialize(int playerId, string playerName) {
         ownerId = playerId;
         PlayerNameText.text = playerName;
+        PlayerNameText.color = Color.black;
+        isPlayerReady = false;
+    }
+
+    public void Start() {
+        if (PhotonNetwork.LocalPlayer.ActorNumber != ownerId) {
+            PlayerReadyButton.gameObject.SetActive(false);
+        } else {
+            PlayerReadyButton.onClick.AddListener(() => {
+                isPlayerReady = !isPlayerReady;
+                SetPlayerReady(isPlayerReady);
+
+                PhotonHashtable props = new PhotonHashtable() {{"PLAYER_READY_KEY", isPlayerReady}};
+                PhotonNetwork.LocalPlayer.SetCustomProperties(props);
+
+                if (PhotonNetwork.IsMasterClient) {
+                    FindObjectOfType<NetworkController>().LocalPlayerPropertiesUpdated();
+                }
+            });
+        }
+    }
+
+    public void SetPlayerReady(bool playerReady) {
+        PlayerReadyButton.GetComponentInChildren<Text>().text = playerReady ? "Ready?" : "Ready!";
+        PlayerNameText.gameObject.GetComponent<Text>().color = playerReady ? PlayerReadyColor : Color.black;
     }
 }

--- a/Assets/Scripts/PlayerListEntry.cs
+++ b/Assets/Scripts/PlayerListEntry.cs
@@ -8,6 +8,7 @@ using Photon.Pun;
 using Photon.Realtime;
 
 using PhotonHashtable = ExitGames.Client.Photon.Hashtable;
+using PhotonPlayer = Photon.Realtime.Player;
 
 public class PlayerListEntry : MonoBehaviour {
 
@@ -26,6 +27,7 @@ public class PlayerListEntry : MonoBehaviour {
     }
 
     public void Start() {
+        // Only show player's own ready button
         if (PhotonNetwork.LocalPlayer.ActorNumber != ownerId) {
             PlayerReadyButton.gameObject.SetActive(false);
         } else {


### PR DESCRIPTION
**Description**
- New PlayerReadyButton for local players to set their readiness. Host can only start game when all players in room are ready. Green text to show when players are ready.
![image](https://user-images.githubusercontent.com/28535405/72057707-c5887c80-3309-11ea-9509-4d0641e714a7.png)
![image](https://user-images.githubusercontent.com/28535405/72057720-ccaf8a80-3309-11ea-9577-4c6cac7de1d2.png)

- Connection status text now also shows region in lobby and room name in room info
![image](https://user-images.githubusercontent.com/28535405/72057683-bd304180-3309-11ea-8d69-bf12c05decfc.png)
![image](https://user-images.githubusercontent.com/28535405/72057736-d46f2f00-3309-11ea-95f3-5ccf3eb04462.png)

@khooroko
@lyhvictoria

**Impact**
If impact is minor, no need for the reviewer to check out the branch to test locally before approval
- [ ] Major
- [x] Medium
- [ ] Minor
