### PR TITLE
Escape menu fixes

### DIFF
--- a/Assets/Prefabs/Resources/OVRPlayer.prefab
+++ b/Assets/Prefabs/Resources/OVRPlayer.prefab
@@ -252,7 +252,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &71325662272139834
 Transform:
   m_ObjectHideFlags: 0
@@ -275,7 +275,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 71325662272433690}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: df9f338034892c44ebb62d97894772f1, type: 3}
   m_Name: 
@@ -290,7 +290,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 71325662272433690}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7e933e81d3c20c74ea6fdc708a67e3a5, type: 3}
   m_Name: 
@@ -750,6 +750,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 71325662272139836}
     m_Modifications:
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_Name
+      value: GoalPost
+      objectReference: {fileID: 0}
     - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -805,11 +810,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: m_Name
-      value: GoalPost
-      objectReference: {fileID: 0}
     - target: {fileID: 6518231945215148719, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -825,7 +825,12 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3385298636954653196, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    - target: {fileID: 8253398896947689217, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: viewIdField
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 837993900814087325, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: viewIdField
       value: 0
@@ -835,12 +840,7 @@ PrefabInstance:
       propertyPath: viewIdField
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8253398896947689217, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: viewIdField
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 837993900814087325, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    - target: {fileID: 3385298636954653196, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: viewIdField
       value: 0
@@ -878,15 +878,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5798643184190185188}
     m_Modifications:
-    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: handSide
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
       value: LeftHand
+      objectReference: {fileID: 0}
+    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: vibration.actionPath
+      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 7965826471793230937, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -943,10 +943,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
-      propertyPath: vibration.actionPath
-      value: /actions/default/out/Haptic
+      propertyPath: handSide
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7405048378267027422, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1045,15 +1045,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5798643184190185188}
     m_Modifications:
-    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: handSide
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
       value: RightHand
+      objectReference: {fileID: 0}
+    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: vibration.actionPath
+      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 7965826471793230937, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1110,10 +1110,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
-      propertyPath: vibration.actionPath
-      value: /actions/default/out/Haptic
+      propertyPath: handSide
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -157,6 +157,10 @@ MeshRenderer:
   m_RendererPriority: 0
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Scripts/EscapeMenu.cs
+++ b/Assets/Scripts/EscapeMenu.cs
@@ -30,7 +30,15 @@ public class EscapeMenu : MonoBehaviourPunCallbacks {
             foreach (GameObject go in oculusObjects) {
                 go.SetActive(true);
             }
-            playerCam = GameObject.Find("CenterEyeAnchor").GetComponent<Camera>();
+            Camera[] cams = FindObjectsOfType<Camera>();
+            foreach (Camera c in cams) {
+                PhotonView pv = c.GetComponentInParent<PhotonView>();
+                if (pv == null || !c.isActiveAndEnabled) {
+                    continue;
+                } else {
+                    playerCam = c;
+                }
+            }
             pauseMenuCanvas.renderMode = RenderMode.ScreenSpaceCamera;
             pauseMenuCanvas.worldCamera = playerCam;
             pauseMenuCanvas.planeDistance = 3f;

--- a/Assets/Scripts/NetworkController.cs
+++ b/Assets/Scripts/NetworkController.cs
@@ -90,14 +90,6 @@ public class NetworkController : MonoBehaviourPunCallbacks, IOnEventCallback {
         PlayerListEntryPrefab = NetworkUIRefs.Instance.PlayerListEntryPrefab;
     }
 
-    public void OnEnable() {
-        PhotonNetwork.AddCallbackTarget(this);
-    }
-
-    public void OnDisable() {
-        PhotonNetwork.RemoveCallbackTarget(this);
-    }
-
     public void OnEvent(EventData photonEvent) {
         byte LeaveGameEvent = 2;
         byte eventCode = photonEvent.Code;
@@ -122,6 +114,7 @@ public class NetworkController : MonoBehaviourPunCallbacks, IOnEventCallback {
             }
 
             if (PhotonNetwork.IsMasterClient) {
+                PhotonNetwork.DestroyAll();
                 PhotonNetwork.LoadLevel(0); // ensure sync is true
             }
         }

--- a/Assets/Scripts/OculusPlayerHandler.cs
+++ b/Assets/Scripts/OculusPlayerHandler.cs
@@ -13,12 +13,14 @@ public class OculusPlayerHandler : MonoBehaviourPunCallbacks {
         leftHand = null,
         rightHand = null;
 
-    // Start is called before the first frame update
-    void Start() {
+    void Awake() {
         if (PhotonNetwork.IsConnected && !photonView.IsMine) {
             goal.transform.parent = transform;
             goal.GetComponent<Goal>().enabled = false;
-            Destroy(oVRCameraRig);
+        } else {
+            oVRCameraRig.SetActive(true);
+            oVRCameraRig.GetComponent<OVRManager>().enabled = true;
+            oVRCameraRig.GetComponent<OVRCameraRig>().enabled = true;
         }
     }
 

--- a/Assets/Scripts/PlayerLoader.cs
+++ b/Assets/Scripts/PlayerLoader.cs
@@ -41,7 +41,7 @@ public class PlayerLoader : MonoBehaviour {
                     SpawnBot();
                     break;
                 case 2:
-                    if (PhotonNetwork.LocalPlayer.ActorNumber == 1) {
+                    if (PhotonNetwork.IsMasterClient) {
                         SpawnHuman(PlayerNumber.ONE);
                     } else {
                         SpawnHuman(PlayerNumber.TWO);


### PR DESCRIPTION
**Description**
Fix a bunch of things that `escapeMenu` made us realise.

- Photon instantiated objects are not destroyed on loading another scene, so if player 1 leaves the room and rejoins, the buffered player and tool objects are spawned in the lobby. Fixed by using `PhotonNetwork.DestroyAll()` in `NetworkController.cs`
- Player 1 leaving the room and joining back causes both players to be spawned on the same side. This was a logical problem in `PlayerLoader.cs` where we check the actornumber. Fixed by checking whether the player is a masterclient instead
- Previously there is one frame where the other player spawning causes the `OVRManager` (and other singletons) to exist for one frame as `Destroy` takes one frame to execute. This will override the existing singletons belonging to the player, and hence mess things up in ways we don't really know. Fix by leaving these disabled in scene, then turned on by script if they belong to the local player

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
Fix 2 will make it hard to go for more than 2 players, but we likely won't so it will do for now

**Test Plan**
Play the game, leave and rejoin rooms