### PR TITLE
Remove GetComponent<PhotonView> from MonoBehaviourPunCallbacks subclasses

### DIFF
--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -204,7 +204,7 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
     [PunRPC]
     private void Ball_SetParent(string parentName) {
         BallManager instance;
-        if (GetComponent<PhotonView>().IsMine) {
+        if (photonView.IsMine) {
             instance = BallManager.LocalInstance;
         } else {
             instance = BallManager.RemoteInstance;

--- a/Assets/Scripts/Human.cs
+++ b/Assets/Scripts/Human.cs
@@ -6,7 +6,6 @@ using Utils;
 using Valve.VR;
 
 public class Human : Player {
-    private PhotonView pv;
     private SteamVR_Behaviour_Pose leftHand;
     private SteamVR_Behaviour_Pose rightHand;
     public SteamVR_Action_Boolean grab = SteamVR_Input.GetAction<SteamVR_Action_Boolean>("GrabGrip");
@@ -16,8 +15,7 @@ public class Human : Player {
 
     protected override void Start() {
         playerType = PlayerType.HUMAN;
-        pv = GetComponent<PhotonView>();
-        if (PhotonNetwork.IsConnected && !pv.IsMine) {
+        if (PhotonNetwork.IsConnected && !photonView.IsMine) {
             foreach (MonoBehaviour m in localScripts) {
                 if (m != null) {
                     m.enabled = false;

--- a/Assets/Scripts/ToolFollower.cs
+++ b/Assets/Scripts/ToolFollower.cs
@@ -8,7 +8,6 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
     private Tool tool;
     private Rigidbody rb;
     private Collider col;
-    private PhotonView pv;
     private Vector3 velocity;
     private bool isHuman;
     private List<Material> materials = new List<Material>();
@@ -35,7 +34,6 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
     private void Awake() {
         rb = GetComponent<Rigidbody>();
         col = GetComponentInChildren<Collider>();
-        pv = GetComponent<PhotonView>();
     }
 
     private void Start() {
@@ -55,7 +53,7 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
     }
 
     private void Update() {
-        if (!PhotonNetwork.IsConnected || pv.IsMine) {
+        if (!PhotonNetwork.IsConnected || photonView.IsMine) {
             HandleFade();
         }
         if (fadeState == FadeState.FADED) {
@@ -67,7 +65,7 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
 
     private void FixedUpdate() {
         if (!isResetting) {
-            if (!PhotonNetwork.IsConnected || pv.IsMine) {
+            if (!PhotonNetwork.IsConnected || photonView.IsMine) {
                 Vector3 destination = tool.transform.position;
                 rb.transform.rotation = transform.rotation;
 
@@ -100,7 +98,7 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
         if (magnitude > velocityLowerThreshold && fadeState < FadeState.NORMAL) {
             float a = Mathf.Clamp(materials[0].color.a + Time.deltaTime * unfadeSpeed, minOpacityValue, 1);
             if (PhotonNetwork.IsConnected) {
-                pv.RPC("ToolFollower_SetAlpha", RpcTarget.AllBuffered, a);
+                photonView.RPC("ToolFollower_SetAlpha", RpcTarget.AllBuffered, a);
             } else {
                 ToolFollower_SetAlpha(a);
             }
@@ -116,7 +114,7 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
             } else if (Time.time - fadeStartTime > fadeDelay) {
                 float a = Mathf.Clamp(materials[0].color.a - Time.deltaTime, minOpacityValue, 1);
                 if (PhotonNetwork.IsConnected) {
-                    pv.RPC("ToolFollower_SetAlpha", RpcTarget.AllBuffered, a);
+                    photonView.RPC("ToolFollower_SetAlpha", RpcTarget.AllBuffered, a);
                 } else {
                     ToolFollower_SetAlpha(a);
                 }
@@ -131,7 +129,7 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
 
     private void OnCollisionEnter(Collision collision) {
         if (isHuman) {
-            if (!PhotonNetwork.IsConnected || pv.IsMine) {
+            if (!PhotonNetwork.IsConnected || photonView.IsMine) {
                 ((ToolHuman)tool).TriggerHapticFeedback(0.1f, 100, 30);
             }
         }
@@ -179,7 +177,7 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
 
     public void SetActive(bool active) {
         if (PhotonNetwork.IsConnected) {
-            pv.RPC("ToolFollower_SetState", RpcTarget.AllBuffered, active);
+            photonView.RPC("ToolFollower_SetState", RpcTarget.AllBuffered, active);
         } else {
             ToolFollower_SetState(active);
         }
@@ -195,7 +193,7 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
 
     public void FlipCollider() {
         if (PhotonNetwork.IsConnected) {
-            pv.RPC("ToolFollower_FlipCollider", RpcTarget.AllBuffered);
+            photonView.RPC("ToolFollower_FlipCollider", RpcTarget.AllBuffered);
         } else {
             ToolFollower_FlipCollider();
         }


### PR DESCRIPTION
**Description**
Classes that inherit from `MonoBehaviourPunCallbacks` do not require another reference to the gameobject's photonview component as it is cached

@lyhvictoria

**Impact**
- [x] Minor