### PR TITLE
Turn off ball gravity in hand

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -42,5 +42,6 @@ MonoBehaviour:
   - ToolFollower_SetAlpha
   - ToolFollower_SetState
   - ToolFollower_FlipCollider
+  - Ball_SetUseGravity
   DisableAutoOpenWizard: 1
   ShowSettings: 1

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -127,6 +127,7 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
         transformToFollow = hand;
         transform.position = hand.position;
         rb.isKinematic = true;
+        SetUseGravity(false);
         col.enabled = false;
         SetState(true);
     }
@@ -145,6 +146,7 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
         throwVecetor *= forceMultiplier;
         transformToFollow = null;
         rb.isKinematic = false;
+        SetUseGravity(true);
         col.enabled = true;
         rb.AddForce(throwVecetor, ForceMode.Impulse);
         SetParent(BallManager.LocalInstance.activeBalls);
@@ -183,6 +185,26 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
         countTimeLived = false;
         InitLists();
         BallManager.LocalInstance.PutBallInQueue(this);
+    }
+
+    [PunRPC]
+    private void Ball_SetUseGravity(bool shouldUseGravity) {
+        if (rb == null) {
+            rb = GetComponent<Rigidbody>();
+        }
+        if (shouldUseGravity) {
+            rb.useGravity = true;
+        } else {
+            rb.useGravity = false;
+        }
+    }
+
+    private void SetUseGravity(bool shouldUseGravity) {
+        if (PhotonNetwork.IsConnected) {
+            photonView.RPC("Ball_SetUseGravity", RpcTarget.All, shouldUseGravity);
+        } else {
+            Ball_SetUseGravity(shouldUseGravity);
+        }
     }
 
     [PunRPC]


### PR DESCRIPTION
**Description**
If a player (p1) holds the trigger and doesn't move his/her hand, i.e. the ball is held in place, then on the other player's (p2) screen it will look as though p1 is dropping it repeatedly. This is because the syncing in position doesn't run unless there is some displacement on the p1's side, and the code for the ball to follow the hand is only called by p1, so the ball would follow normal rigidbody physics and in this case gravity is turned on so it drops. Only after dropping a certain distance will Photon teleport it back to where it really is

@lyhvictoria

**Impact**
- [x] Minor