### PR TITLE
Fix scoring on spawn

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -43,5 +43,6 @@ MonoBehaviour:
   - ToolFollower_SetState
   - ToolFollower_FlipCollider
   - Ball_SetUseGravity
+  - Ball_SetPosition
   DisableAutoOpenWizard: 1
   ShowSettings: 1

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -125,7 +125,7 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
         }
         prevPos = hand.position;
         transformToFollow = hand;
-        transform.position = hand.position;
+        SetPosition(hand.transform.position);
         rb.isKinematic = true;
         SetUseGravity(false);
         col.enabled = false;
@@ -187,6 +187,19 @@ public class Ball : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallback {
         BallManager.LocalInstance.PutBallInQueue(this);
     }
 
+    [PunRPC]
+    private void Ball_SetPosition(float x, float y, float z) {
+        transform.position = new Vector3(x, y, z);
+    }
+
+    public void SetPosition(Vector3 newPos) {
+        if (PhotonNetwork.IsConnected) {
+            photonView.RPC("Ball_SetPosition", RpcTarget.All, newPos.x, newPos.y, newPos.z);
+        } else {
+            transform.position = newPos;
+        }
+    }
+    
     [PunRPC]
     private void Ball_SetUseGravity(bool shouldUseGravity) {
         if (rb == null) {


### PR DESCRIPTION
**Description**
Previously there was a significant chance of scoring the moment you change to a spawner if you have previously scored. This was because the change in state from inactive to active happened on the remote player's end before the position got updated. Quite often it looked like the ball was flying back to the thrower's hand on spawn from where the ball last disappeared.

Fix by letting the initial position on spawn be updated through RPC instead of waiting for photonView's sync

@lyhvictoria

**Impact**
- [x] Minor