### PR TITLE
Change escape menu to world space

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -511,7 +511,7 @@ MonoBehaviour:
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
+  m_DynamicPixelsPerUnit: 5
 --- !u!223 &122563619
 Canvas:
   m_ObjectHideFlags: 0
@@ -2228,7 +2228,7 @@ MonoBehaviour:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 20
     m_FontStyle: 0
-    m_BestFit: 0
+    m_BestFit: 1
     m_MinSize: 2
     m_MaxSize: 40
     m_Alignment: 4

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -471,7 +471,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 120}
+  m_SizeDelta: {x: 220, y: 124}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &122563617
 MonoBehaviour:
@@ -1236,7 +1236,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: 0
+  m_Spacing: 5
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -460,9 +460,9 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 122563615}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 1}
   m_Children:
   - {fileID: 1289499906}
   m_Father: {fileID: 1220758415}
@@ -471,8 +471,8 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &122563617
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -521,7 +521,7 @@ Canvas:
   m_GameObject: {fileID: 122563615}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 1
+  m_RenderMode: 2
   m_Camera: {fileID: 0}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
@@ -1124,6 +1124,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1220758415}
   - component: {fileID: 1220758414}
+  - component: {fileID: 1220758416}
   m_Layer: 0
   m_Name: EscapeMenuUI
   m_TagString: Untagged
@@ -1155,14 +1156,27 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1220758413}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 40.30565, y: -43.853367, z: 352.85385}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 6, z: -4.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 122563616}
   m_Father: {fileID: 0}
   m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!114 &1220758416
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1220758413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c4c56254bca29148831709a77b80eef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  canvasRectTransform: {fileID: 122563616}
 --- !u!1 &1289499905
 GameObject:
   m_ObjectHideFlags: 0
@@ -1242,7 +1256,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.78431374}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/Assets/Scripts/EscapeMenu.cs
+++ b/Assets/Scripts/EscapeMenu.cs
@@ -8,7 +8,6 @@ using Photon.Pun;
 using Photon.Realtime;
 
 public class EscapeMenu : MonoBehaviourPunCallbacks {
-    private Camera playerCam;
     private bool isEscaped = false;
     public Canvas pauseMenuCanvas;
 
@@ -36,19 +35,6 @@ public class EscapeMenu : MonoBehaviourPunCallbacks {
                     laserLineRenderer = go.GetComponentInChildren<LineRenderer>();
                 }
             }
-            Camera[] cams = FindObjectsOfType<Camera>();
-            foreach (Camera c in cams) {
-                PhotonView pv = c.GetComponentInParent<PhotonView>();
-                if (pv == null || !c.isActiveAndEnabled) {
-                    continue;
-                } else {
-                    playerCam = c;
-                    break;
-                }
-            }
-            pauseMenuCanvas.renderMode = RenderMode.ScreenSpaceCamera;
-            pauseMenuCanvas.worldCamera = playerCam;
-            pauseMenuCanvas.planeDistance = 3f;
         }
         pauseMenuCanvas.gameObject.SetActive(false);
     }

--- a/Assets/Scripts/EscapeMenu.cs
+++ b/Assets/Scripts/EscapeMenu.cs
@@ -11,6 +11,10 @@ public class EscapeMenu : MonoBehaviourPunCallbacks {
     private bool isEscaped = false;
     public Canvas pauseMenuCanvas;
 
+    #if UNITY_EDITOR
+    private Camera playerCam;
+    #endif
+
     [Header("Desktop")]
     [SerializeField]
     private GameObject[] desktopObjects = null;
@@ -36,6 +40,23 @@ public class EscapeMenu : MonoBehaviourPunCallbacks {
                 }
             }
         }
+
+        #if UNITY_EDITOR
+        Camera[] cams = FindObjectsOfType<Camera>();
+        foreach (Camera c in cams) {
+            PhotonView pv = c.GetComponentInParent<PhotonView>();
+            if (pv == null || !c.isActiveAndEnabled) {
+                continue;
+            } else {
+                playerCam = c;
+                break;
+            }
+        }
+        pauseMenuCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        pauseMenuCanvas.worldCamera = playerCam;
+        GetComponent<VRFollowCanvas>().enabled = false;
+        #endif
+
         pauseMenuCanvas.gameObject.SetActive(false);
     }
 
@@ -52,13 +73,19 @@ public class EscapeMenu : MonoBehaviourPunCallbacks {
     #endregion
 
     private bool TogglePause() {
+        #if !UNITY_EDITOR
+        if (!isEscaped) {
+            laserLineRenderer.enabled = true;
+        } else {
+            laserLineRenderer.enabled = false;
+        }
+        #endif
+
         if (!isEscaped) {
             pauseMenuCanvas.gameObject.SetActive(true);
-            laserLineRenderer.enabled = true;
             return true;
         } else {
             pauseMenuCanvas.gameObject.SetActive(false);
-            laserLineRenderer.enabled = false;
             return false;
         }
     }

--- a/Assets/Scripts/VRFollowCanvas.cs
+++ b/Assets/Scripts/VRFollowCanvas.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+using ExitGames.Client.Photon;
+using Photon.Pun;
+using Photon.Realtime;
+
+public class VRFollowCanvas : MonoBehaviour {
+    public RectTransform canvasRectTransform; // rectangle transform of canvas
+    private Camera playerCam;
+
+    enum CanvasState { 
+        InScreen,
+        NotInScreen,
+        Moving };
+    private CanvasState currentState;
+    
+    void Start () {
+        Camera[] cams = FindObjectsOfType<Camera>();
+        foreach (Camera c in cams) {
+            PhotonView pv = c.GetComponentInParent<PhotonView>();
+            if (pv == null || !c.isActiveAndEnabled) {
+                continue;
+            } else {
+                playerCam = c;
+                break;
+            }
+        }
+        currentState = CanvasState.InScreen;
+    }
+    
+    void Update () {
+        switch (currentState) {
+            case CanvasState.InScreen:
+                if (!IsFullyVisibleFrom(canvasRectTransform, playerCam)) {
+                    // If the menu isn't fully visible anymore switch to NotInScreen state.
+                    currentState = CanvasState.NotInScreen;
+                }
+                break;
+            case CanvasState.NotInScreen:
+                // If the menu isn't in the screen anymore, start moving it towards the player.
+                currentState = CanvasState.Moving;
+                StartCoroutine(MoveToFrontOfPlayer());
+                break;
+        }
+    }
+
+    // Get the foward Vector of camera with offset 
+    private Vector3 GetFrontOfPlayer() {
+        float distance = 3.0f;
+        Vector3 forward = playerCam.transform.position + playerCam.transform.forward * distance;
+        return forward;
+    }
+
+    // Move canvas to the front of player every frame
+    private IEnumerator MoveToFrontOfPlayer() {
+        while (Vector3.Distance(transform.position, GetFrontOfPlayer()) >= 0.05f) {
+            transform.eulerAngles = playerCam.transform.eulerAngles;
+            float speed = 4f * Time.deltaTime;
+            transform.position = Vector3.MoveTowards(transform.position, GetFrontOfPlayer(), speed);
+            yield return null;
+        }
+        currentState = CanvasState.InScreen;
+    }
+
+    // Returns amount of bounding box corners that are visible from the Camera or -1 if a corner isn't in the screen
+    private int CountCornersVisibleFrom(RectTransform rectTransform, Camera camera) {
+        // Screen space bounds (assumes camera renders across the entire screen)
+        Rect screenBounds = new Rect(0f, 0f, Screen.width, Screen.height);
+        Vector3[] objectCorners = new Vector3[4];
+        rectTransform.GetWorldCorners(objectCorners);
+
+        int visibleCorners = 0;
+        // For each corner in rectTransform
+        for (var i = 0; i < objectCorners.Length; i++) {
+            // Transform world space position of corner to screen space
+            Vector3 tempScreenSpaceCorner = camera.WorldToScreenPoint(objectCorners[i]);
+            // If the corner is inside the screen
+            if (screenBounds.Contains(tempScreenSpaceCorner)) {
+                visibleCorners++;
+            } else {
+                return -1;
+            }
+        }
+
+        return visibleCorners;
+    }
+
+    // Determines if this RectTransform is fully visible from the specified camera.
+    private bool IsFullyVisibleFrom(RectTransform rectTransform, Camera camera) {
+        return CountCornersVisibleFrom(rectTransform, camera) == 4; // True if all 4 corners are visible
+    }
+}

--- a/Assets/Scripts/VRFollowCanvas.cs.meta
+++ b/Assets/Scripts/VRFollowCanvas.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c4c56254bca29148831709a77b80eef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,19 +5,19 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/LobbyScene.unity
     guid: 28f487c1c9d1a404aa0345677abf67f8
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/MainScene.unity
     guid: dfe30ae92277edb4cb31b21f40184412
-  - enabled: 1
+  - enabled: 0
     path: Assets/Movesense/ExampleScenes/ScanScene.unity
     guid: 36a1b9088fe934fae8287df85cac1bca
-  - enabled: 1
+  - enabled: 0
     path: Assets/Movesense/ExampleScenes/SubscriptionScene.unity
     guid: 44e7cbd76c19f49ee92e02e73ff8eef8
-  - enabled: 1
+  - enabled: 0
     path: Assets/Movesense/ExampleScenes/VisualizationScene.unity
     guid: fa57b6e7faa0c4e5b81f53b2bc089712
   m_configObjects: {}


### PR DESCRIPTION
**Description**
Having the escape menu in screen space is bad for VR, The new escape menu will self position to the front of the player's camera once its out of view.
- Escape menu for unity editor will be set to screen space overlay since its on a monitor anyway, but the default remains as world space.
- Increased dynamic pixels per unit for the canvas since text feels blurry

**Before**
![image](https://user-images.githubusercontent.com/28535405/74912756-456e3000-53fa-11ea-812c-b44010a61c3e.png)
**After**
![image](https://user-images.githubusercontent.com/28535405/74912735-3a1b0480-53fa-11ea-9a8b-ea380efb86fe.png)

@khooroko 

**Impact**
If impact is minor, no need for the reviewer to check out the branch to test locally before approval
- [x] Medium

**Risks**
If the player tilts their head to un-comfortable angles while the menu is moving and reached the destination, it will remain with the rotation of that un-comfortable angle.

**Test Plan**
Please try as both player 1 and player 2