### PR TITLE
Make leave from rematch go to room

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -2807,6 +2807,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3cff98ee266a1724f8c170c1c47a5e48, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  leaveGameButton: {fileID: 1095172498}
+  restartGameButton: {fileID: 2125927785}
 --- !u!1 &384055799
 GameObject:
   m_ObjectHideFlags: 0
@@ -6335,7 +6337,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 377827013}
-        m_MethodName: LeaveRoomAlone
+        m_MethodName: OnLeavePressed
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/NetworkController.cs
+++ b/Assets/Scripts/NetworkController.cs
@@ -10,6 +10,7 @@ using Photon.Realtime;
 using PhotonHashtable = ExitGames.Client.Photon.Hashtable;
 using PhotonPlayer = Photon.Realtime.Player;
 using UnityEngine.SceneManagement;
+using UnityEngine.Events;
 
 public class NetworkController : MonoBehaviourPunCallbacks, IOnEventCallback {
     public static NetworkController Instance;
@@ -33,6 +34,8 @@ public class NetworkController : MonoBehaviourPunCallbacks, IOnEventCallback {
     private Dictionary<int, GameObject> playerListEntries;
 
     private bool isReturnToRoom = false;
+
+    public UnityEvent readyToLeaveEvent;
 
     void Awake() {
         InitInstance();
@@ -93,6 +96,7 @@ public class NetworkController : MonoBehaviourPunCallbacks, IOnEventCallback {
 
     public void OnEvent(EventData photonEvent) {
         byte LeaveGameEvent = 2;
+        byte ReadyToLeaveEvent = 3;
         byte eventCode = photonEvent.Code;
 
         if (eventCode == LeaveGameEvent) {
@@ -117,6 +121,10 @@ public class NetworkController : MonoBehaviourPunCallbacks, IOnEventCallback {
                 PhotonNetwork.DestroyAll();
                 PhotonNetwork.LoadLevel(0); // ensure sync is true
             }
+        } else if (eventCode == ReadyToLeaveEvent) {
+            Debug.Log("Event received: Ready To Leave Game Event");
+            readyToLeaveEvent.Invoke();
+            DisableReadyButtons();
         }
     }
 
@@ -336,6 +344,12 @@ public class NetworkController : MonoBehaviourPunCallbacks, IOnEventCallback {
         foreach (PhotonPlayer p in PhotonNetwork.PlayerList) {
             PhotonHashtable props = new PhotonHashtable() { { "PLAYER_READY_KEY", false } };
             p.SetCustomProperties(props);
+        }
+    }
+
+    public void DisableReadyButtons() {
+        foreach (GameObject entry in playerListEntries.Values) {
+            entry.GetComponentInChildren<Button>().gameObject.SetActive(false);
         }
     }
 }

--- a/Assets/Scripts/RematchManager.cs
+++ b/Assets/Scripts/RematchManager.cs
@@ -1,31 +1,62 @@
-﻿using System.Collections;
+﻿using ExitGames.Client.Photon;
+using Photon.Pun;
+using Photon.Realtime;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class RematchManager : MonoBehaviour {
     private Canvas rematchCanvas;
+    [SerializeField]
+    private Button
+        leaveGameButton,
+        restartGameButton;
+    private bool otherPlayerReadyToLeave = false;
+
+    private readonly byte LeaveGameEvent = 2;
+    private readonly byte ReadyToLeaveEvent = 3;
 
     // Start is called before the first frame update
     void Start() {
         rematchCanvas = GetComponentInChildren<Canvas>();
         rematchCanvas.gameObject.SetActive(false);
+        if (PhotonNetwork.IsConnected && PhotonNetwork.CurrentRoom.PlayerCount > 1) {
+            NetworkController.Instance.readyToLeaveEvent.AddListener(SetOtherPlayerReadyToLeave);
+        } else {
+            // bot is always ready to leave
+            SetOtherPlayerReadyToLeave();
+        }
     }
 
-    // Leave room without forcing the other player out
-    public void LeaveRoomAlone() {
-        #if !UNITY_EDITOR
-        OculusUIHandler.instance.laserLineRenderer.enabled = false;
-        #endif
-        if (NetworkController.Instance != null) {
-            NetworkController.Instance.PlayerLeaveRoom();
-        } else {    // Probably lobby not loaded/built
+    public void OnLeavePressed() {
+        if (NetworkController.Instance == null) {
             #if UNITY_EDITOR
             EditorApplication.Exit(0);
             #else
             Application.Quit();
-            #endif       
+            #endif
+            return;
         }
+        if (otherPlayerReadyToLeave) {  // send a leave game event
+            object[] content = new object[] { false, false }; // isReturnToLobby (false), isHostDecision (doesn't matter)
+            RaiseEventOptions raiseEventOptions = new RaiseEventOptions { Receivers = ReceiverGroup.All };
+            SendOptions sendOptions = new SendOptions { Reliability = true };
+            PhotonNetwork.RaiseEvent(LeaveGameEvent, content, raiseEventOptions, sendOptions);
+        } else {    // send a ready to leave event
+            leaveGameButton.GetComponentInChildren<Text>().text = "Leave request sent!";
+            leaveGameButton.interactable = false;
+            restartGameButton.gameObject.SetActive(false);
+            object[] content = new object[] { };
+            RaiseEventOptions raiseEventOptions = new RaiseEventOptions { Receivers = ReceiverGroup.All };
+            SendOptions sendOptions = new SendOptions { Reliability = true };
+            PhotonNetwork.RaiseEvent(ReadyToLeaveEvent, content, raiseEventOptions, sendOptions);
+        }
+    }
+
+    public void SetOtherPlayerReadyToLeave() {
+        otherPlayerReadyToLeave = true;
     }
 
     public void Restart() {


### PR DESCRIPTION
**Description**
With room settings coming into play soon, it becomes more desirable to make the leave button go back to the room instead of to the lobby. When a player presses leave from the rematch UI, ready buttons become inactive for both players, and the start button is inactive for the host.
The leave button of the person who pressed it also changes text to "Leave request sent!" and becomes uninteractable.
Once both players have pressed the leave button, they are both taken back to the room.

@lyhvictoria

**Impact**
- [x] Minor

**Risks**
Touched main scene