### PR TITLE
Fix multiple movesense subscriber gameobjects

### DIFF
--- a/Assets/Scripts/MovesenseSubscriber.cs
+++ b/Assets/Scripts/MovesenseSubscriber.cs
@@ -10,7 +10,11 @@ public class MovesenseSubscriber : MonoBehaviour {
     public bool isConnected = false;
 
     private void Awake() {
-        instance = this;
+        if (instance == null) {
+            instance = this;
+        } else if (instance != this) {
+            Destroy(gameObject);
+        }
     }
     // Start is called before the first frame update
     void Start() {


### PR DESCRIPTION
**Description**
Previously switching between scenes causes more MovesenseSubscriber gameobjects to spawn, and the instance always refers to the newest one. Functionally no issue but it's not nice to have so many useless gameobjects floating around.

No functional difference in this pr

@lyhvictoria

**Impact**
- [x] Minor