### PR TITLE
Playtest logging

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -11231,6 +11231,49 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1910841520}
   m_CullTransparentMesh: 0
+--- !u!1 &1935334469
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1935334471}
+  - component: {fileID: 1935334470}
+  m_Layer: 0
+  m_Name: PlayTestLogger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1935334470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1935334469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8be1d0956a33934093ef61cb2179bba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1935334471
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1935334469}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.282414, y: 6.737579, z: -5.6916056}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1935457002
 GameObject:
   m_ObjectHideFlags: 0
@@ -11592,11 +11635,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1372180345}
     m_Modifications:
-    - target: {fileID: -927199367670048503, guid: d57ec60e928915b469ce636395c98408,
-        type: 3}
-      propertyPath: m_Name
-      value: spawnerhandblend
-      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d57ec60e928915b469ce636395c98408,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -11651,6 +11689,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: d57ec60e928915b469ce636395c98408,
+        type: 3}
+      propertyPath: m_Name
+      value: spawnerhandblend
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d57ec60e928915b469ce636395c98408, type: 3}

--- a/Assets/Scripts/CalorieManager.cs
+++ b/Assets/Scripts/CalorieManager.cs
@@ -101,6 +101,12 @@ public class CalorieManager : MonoBehaviourPunCallbacks {
         return calories;
     }
 
+    private void OnCaloriesCalculated(int caloriesBurnt) {
+        PlaytestRecording.RecordCaloriesBurnt(caloriesBurnt);
+        PlaytestRecording.WriteLog();
+        caloriesBurntText.text = caloriesBurnt.ToString();
+    }
+
     public void ShowCalorieUI() {
         Debug.Log("CalorieManager: Match over showing calorie UI");
 
@@ -133,8 +139,7 @@ public class CalorieManager : MonoBehaviourPunCallbacks {
                 // Disable re-saving to prevent user confusion
                 caloriePanel.GetComponentInChildren<Toggle>(true).gameObject.SetActive(false);
                 int caloriesBurnt = CalculateCalories();
-                PlaytestRecording.RecordCaloriesBurnt(caloriesBurnt);
-                caloriesBurntText.text = caloriesBurnt.ToString();
+                OnCaloriesCalculated(caloriesBurnt);
             } else {
                 genderPanel.SetActive(true);
                 caloriePanel.GetComponentInChildren<Toggle>(true).gameObject.SetActive(true);
@@ -156,7 +161,7 @@ public class CalorieManager : MonoBehaviourPunCallbacks {
             caloriePanel.SetActive(true);
 
             int caloriesBurnt = CalculateCalories();
-            caloriesBurntText.text = caloriesBurnt.ToString();
+            OnCaloriesCalculated(caloriesBurnt);
             return;
         }
         if (caloriePanel.activeInHierarchy) {

--- a/Assets/Scripts/CalorieManager.cs
+++ b/Assets/Scripts/CalorieManager.cs
@@ -133,6 +133,7 @@ public class CalorieManager : MonoBehaviourPunCallbacks {
                 // Disable re-saving to prevent user confusion
                 caloriePanel.GetComponentInChildren<Toggle>(true).gameObject.SetActive(false);
                 int caloriesBurnt = CalculateCalories();
+                PlaytestRecording.RecordCaloriesBurnt(caloriesBurnt);
                 caloriesBurntText.text = caloriesBurnt.ToString();
             } else {
                 genderPanel.SetActive(true);

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -42,6 +42,7 @@ public class GameManager : MonoBehaviourPunCallbacks {
             }
         }
         timeLeft = gameDuration;
+        PlaytestRecording.RecordRoundDuration((int)gameDuration / 60);
     }
 
     private void Update() {

--- a/Assets/Scripts/Goal.cs
+++ b/Assets/Scripts/Goal.cs
@@ -279,6 +279,7 @@ public class Goal : MonoBehaviourPunCallbacks, IOnEventCallback {
                         StartCoroutine(ShowGoalHitFor(0.5f));
                         Instantiate(sparkPrefab, col.transform.position, Quaternion.identity);
                     }
+                    PlaytestRecording.RecordGoalScored();
                 }
             }
         }

--- a/Assets/Scripts/GoalSwitcher.cs
+++ b/Assets/Scripts/GoalSwitcher.cs
@@ -49,5 +49,6 @@ public class GoalSwitcher : MonoBehaviour {
                 break;
         }
         GoalInitEvent.Invoke();
+        PlaytestRecording.RecordGoalType(goalType);
     }
 }

--- a/Assets/Scripts/OculusUIHandler.cs
+++ b/Assets/Scripts/OculusUIHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Android;
 using UnityEngine.SceneManagement;
 
 public class OculusUIHandler : MonoBehaviour {
@@ -49,6 +50,11 @@ public class OculusUIHandler : MonoBehaviour {
                 // UIHelpers must be the first go in oculusObjects
                 if (laserLineRenderer == null) {
                     laserLineRenderer = go.GetComponentInChildren<LineRenderer>();
+                }
+            }
+            if (SceneManager.GetActiveScene().buildIndex == 0) {
+                if (!Permission.HasUserAuthorizedPermission(Permission.ExternalStorageWrite)) {
+                    Permission.RequestUserPermission(Permission.ExternalStorageWrite);
                 }
             }
         }

--- a/Assets/Scripts/PlaytestRecording.cs
+++ b/Assets/Scripts/PlaytestRecording.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class PlaytestRecording : MonoBehaviour {
+    string  fileName = "PlayTestLog.txt";
+    private static int
+        numThrows,
+        numHits,
+        numGoalsScored,
+        caloriesBurnt;
+    // Start is called before the first frame update
+    void Start() {
+        ResetLog();
+        GameManager.Instance.TimeOverEvent.AddListener(WriteLog);
+        GameManager.Instance.RestartEvent.AddListener(ResetLog);
+    }
+
+    private void ResetLog() {
+        numThrows = 0;
+        numHits = 0;
+        numGoalsScored = 0;
+        caloriesBurnt = 0;
+
+    }
+
+    public static void RecordHit() {
+        numHits++;
+    }
+
+    public static void RecordThrow() {
+        numThrows++;
+    }
+
+    public static void RecordGoalScored() {
+        numGoalsScored++;
+    }
+
+    public static void RecordCaloriesBurnt(int cal) {
+        caloriesBurnt = cal;
+    }
+
+    private void WriteLog() {
+        string path = "Assets/Resources/" + fileName;
+
+        //Write some text to the test.txt file
+        StreamWriter sw = new StreamWriter(path, true);
+        sw.Write("\n");
+        sw.WriteLine("===== Playtest Log =====");
+        sw.WriteLine("------------------------");
+        sw.Write("\n");
+
+        // Log stuff here
+        sw.WriteLine("1. Number of Balls Thrown:" + numThrows);
+        sw.WriteLine("2. Number of Balls Hit:" + numHits);
+        sw.WriteLine("3. Number of Goals Scored:" + numGoalsScored);
+        sw.WriteLine("4. Number of Calories Burnt:" + caloriesBurnt);
+
+        sw.Write("\n");
+        sw.WriteLine("Timestamp: " + System.DateTime.Now);
+        sw.WriteLine("------------------------");
+        sw.WriteLine("========================");
+        sw.Close();
+    }
+}

--- a/Assets/Scripts/PlaytestRecording.cs
+++ b/Assets/Scripts/PlaytestRecording.cs
@@ -2,14 +2,17 @@
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
+using UnityEngine.Android;
 
 public class PlaytestRecording : MonoBehaviour {
-    string  fileName = "PlayTestLog.txt";
+    string fileName = "PlayTestLog.txt";
     private static int
         numThrows,
         numHits,
         numGoalsScored,
         caloriesBurnt;
+    private static GoalType goalType;
+
     // Start is called before the first frame update
     void Start() {
         ResetLog();
@@ -22,7 +25,7 @@ public class PlaytestRecording : MonoBehaviour {
         numHits = 0;
         numGoalsScored = 0;
         caloriesBurnt = 0;
-
+        // do not reset goalType
     }
 
     public static void RecordHit() {
@@ -41,8 +44,24 @@ public class PlaytestRecording : MonoBehaviour {
         caloriesBurnt = cal;
     }
 
+    public static void RecordGoalType(GoalType type) {
+        goalType = type;
+    }
+
     private void WriteLog() {
-        string path = "Assets/Resources/" + fileName;
+        string path;
+        #if UNITY_EDITOR
+        path = "Assets/Resources/" + fileName;
+        #elif UNITY_ANDROID
+        if (!Permission.HasUserAuthorizedPermission(Permission.ExternalStorageWrite)) {
+            Debug.Log("No write permission. Not recording log for this game");
+            return;
+        } else {
+            path = Application.persistentDataPath + "/" + fileName;
+        }
+        #else
+        path = Application.persistentDataPath + "/" + fileName;
+        #endif
 
         //Write some text to the test.txt file
         StreamWriter sw = new StreamWriter(path, true);
@@ -56,6 +75,7 @@ public class PlaytestRecording : MonoBehaviour {
         sw.WriteLine("2. Number of Balls Hit:" + numHits);
         sw.WriteLine("3. Number of Goals Scored:" + numGoalsScored);
         sw.WriteLine("4. Number of Calories Burnt:" + caloriesBurnt);
+        sw.WriteLine("5. Type of Goal:" + goalType.ToString());
 
         sw.Write("\n");
         sw.WriteLine("Timestamp: " + System.DateTime.Now);

--- a/Assets/Scripts/PlaytestRecording.cs
+++ b/Assets/Scripts/PlaytestRecording.cs
@@ -10,7 +10,8 @@ public class PlaytestRecording : MonoBehaviour {
         numThrows,
         numHits,
         numGoalsScored,
-        caloriesBurnt;
+        caloriesBurnt,
+        roundDuration;
     private static GoalType goalType;
 
     // Start is called before the first frame update
@@ -47,6 +48,10 @@ public class PlaytestRecording : MonoBehaviour {
         goalType = type;
     }
 
+    public static void RecordRoundDuration(int duration) {
+        roundDuration = duration;
+    }
+
     public static void WriteLog() {
         string path;
         #if UNITY_EDITOR
@@ -75,6 +80,7 @@ public class PlaytestRecording : MonoBehaviour {
         sw.WriteLine("3. Number of Goals Scored:" + numGoalsScored);
         sw.WriteLine("4. Number of Calories Burnt:" + caloriesBurnt);
         sw.WriteLine("5. Type of Goal:" + goalType.ToString());
+        sw.WriteLine("6. Round Duration:" + roundDuration + (roundDuration == 1 ? " minute" : " minutes"));
 
         sw.Write("\n");
         sw.WriteLine("Timestamp: " + System.DateTime.Now);

--- a/Assets/Scripts/PlaytestRecording.cs
+++ b/Assets/Scripts/PlaytestRecording.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using UnityEngine.Android;
 
 public class PlaytestRecording : MonoBehaviour {
-    string fileName = "PlayTestLog.txt";
+    private static readonly string fileName = "PlayTestLog.txt";
     private static int
         numThrows,
         numHits,
@@ -16,7 +16,6 @@ public class PlaytestRecording : MonoBehaviour {
     // Start is called before the first frame update
     void Start() {
         ResetLog();
-        GameManager.Instance.TimeOverEvent.AddListener(WriteLog);
         GameManager.Instance.RestartEvent.AddListener(ResetLog);
     }
 
@@ -48,7 +47,7 @@ public class PlaytestRecording : MonoBehaviour {
         goalType = type;
     }
 
-    private void WriteLog() {
+    public static void WriteLog() {
         string path;
         #if UNITY_EDITOR
         path = "Assets/Resources/" + fileName;

--- a/Assets/Scripts/PlaytestRecording.cs.meta
+++ b/Assets/Scripts/PlaytestRecording.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8be1d0956a33934093ef61cb2179bba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -36,6 +36,7 @@ public class Spawner : MonoBehaviour {
         anim.SetTrigger("throw");
         currentBall.OnDetachFromHand();
         currentBall = null;
+        PlaytestRecording.RecordThrow();
         // Have a slight delay so that the ball does not immediately hit the tool
         StartCoroutine(DelayAndSwitchToTool(spawnDelay));
     }

--- a/Assets/Scripts/ToolFollower.cs
+++ b/Assets/Scripts/ToolFollower.cs
@@ -141,6 +141,9 @@ public class ToolFollower : MonoBehaviourPunCallbacks, IPunInstantiateMagicCallb
                 Instantiate(sparkPrefab, collision.GetContact(0).point, Quaternion.identity);
             }
         }
+        if (collision.collider.gameObject.layer == LayerMask.NameToLayer("Ball")) {
+            PlaytestRecording.RecordHit();
+        }
     }
 
     // Reset position once collision ends

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -170,7 +170,7 @@ PlayerSettings:
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
   ForceInternetPermission: 0
-  ForceSDCardPermission: 0
+  ForceSDCardPermission: 1
   CreateWallpaper: 0
   APKExpansionFiles: 0
   keepLoadedShadersAlive: 0


### PR DESCRIPTION
**Description**
Log play testing results.
For quest, output will be at `Quest\Internal shared storage\Android\data\com.VRFYP2019.Not_Dodgeball\files\`

@lyhvictoria

**Impact**
- [x] Medium

**Risks**
In the future if we decide to remove calorie UI for people with no movesense we'll need to move `PlaytestRecording.WriteLog();` out. (I moved it away from just being called by TimeOver.invoke because doing that will call the write before calorie calculation)