### PR TITLE
Add line indicators to wall goal type goal prefabs

### DIFF
--- a/Assets/Prefabs/GoalPost.prefab
+++ b/Assets/Prefabs/GoalPost.prefab
@@ -283,8 +283,8 @@ GameObject:
   m_Component:
   - component: {fileID: 6518231945215148719}
   - component: {fileID: 4724688693394326722}
-  - component: {fileID: 3385298636954653196}
-  - component: {fileID: 8881355905617203591}
+  - component: {fileID: 632913871616423946}
+  - component: {fileID: 5724946283556115115}
   m_Layer: 8
   m_Name: GoalIndicatorTL
   m_TagString: Untagged
@@ -318,7 +318,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &3385298636954653196
+  goalType: 0
+  playerHead: {fileID: 0}
+--- !u!114 &632913871616423946
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -333,14 +335,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 8881355905617203591}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &8881355905617203591
+--- !u!114 &5724946283556115115
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -433,6 +434,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 443377d75f2d9024294516cc49180804, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  goalType: 0
   sparkPrefab: {fileID: 526120672898192366, guid: c3869f00f3b3b9941ab0140aff89ca6d,
     type: 3}
   goalSidesMR:
@@ -442,7 +444,6 @@ MonoBehaviour:
   - {fileID: 3317214948058823977}
   - {fileID: 6306494174682287699}
   followingMat: {fileID: 2100000, guid: 85d8e1af79d92f74398661f34bcf0ef5, type: 2}
-  stationaryMat: {fileID: 2100000, guid: fc54cad22d1ea2a45b1ef6240ef664e4, type: 2}
   hitMat: {fileID: 2100000, guid: 476fadb7d5abec4479cd603f6c7154d4, type: 2}
 --- !u!114 &-2794348458829193551
 MonoBehaviour:
@@ -582,8 +583,8 @@ GameObject:
   m_Component:
   - component: {fileID: 7184160366939845539}
   - component: {fileID: 6586924146612473831}
-  - component: {fileID: 3750690968908750511}
-  - component: {fileID: 6093816657346612728}
+  - component: {fileID: 7279449910415554902}
+  - component: {fileID: 243445985522190432}
   m_Layer: 8
   m_Name: GoalIndicatorBL
   m_TagString: Untagged
@@ -617,7 +618,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &3750690968908750511
+  goalType: 0
+  playerHead: {fileID: 0}
+--- !u!114 &7279449910415554902
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -632,14 +635,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 6093816657346612728}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &6093816657346612728
+--- !u!114 &243445985522190432
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -664,8 +666,8 @@ GameObject:
   m_Component:
   - component: {fileID: 5690253060359586818}
   - component: {fileID: 472550232652146210}
-  - component: {fileID: 8253398896947689217}
-  - component: {fileID: 8793234647664314954}
+  - component: {fileID: 5344710270154093174}
+  - component: {fileID: 6028263894000957583}
   m_Layer: 8
   m_Name: GoalIndicatorBR
   m_TagString: Untagged
@@ -699,7 +701,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &8253398896947689217
+  goalType: 0
+  playerHead: {fileID: 0}
+--- !u!114 &5344710270154093174
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -714,14 +718,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 8793234647664314954}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &8793234647664314954
+--- !u!114 &6028263894000957583
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -837,8 +840,8 @@ GameObject:
   m_Component:
   - component: {fileID: 3825304267576250942}
   - component: {fileID: 3327355752699957815}
-  - component: {fileID: 837993900814087325}
-  - component: {fileID: 2185274464990403704}
+  - component: {fileID: 6445963633122547593}
+  - component: {fileID: 8988387893269718364}
   m_Layer: 8
   m_Name: GoalIndicatorTR
   m_TagString: Untagged
@@ -872,7 +875,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &837993900814087325
+  goalType: 0
+  playerHead: {fileID: 0}
+--- !u!114 &6445963633122547593
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -887,14 +892,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 2185274464990403704}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &2185274464990403704
+--- !u!114 &8988387893269718364
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Prefabs/Resources/DummyBot.prefab
+++ b/Assets/Prefabs/Resources/DummyBot.prefab
@@ -480,6 +480,66 @@ PrefabInstance:
       propertyPath: viewIdField
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8885860632723948103, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 6049208041061578322, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 1014642368985210775, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 3635277308618504648, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 8040253552196292621, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 4279073170054498089, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 7387578024545562348, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 5631191206895540985, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 5131651127140508696, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 1507782365198013618, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 2421337536498863116, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
+    - target: {fileID: 2921458173429363437, guid: 83bff4daf25c2f642ac384bc52b8c9fd,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1074984854958102258}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 83bff4daf25c2f642ac384bc52b8c9fd, type: 3}
 --- !u!4 &5318275586353927766 stripped
@@ -495,11 +555,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 228711609}
     m_Modifications:
-    - target: {fileID: -927199367670048503, guid: d57ec60e928915b469ce636395c98408,
-        type: 3}
-      propertyPath: m_Name
-      value: Spawner
-      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d57ec60e928915b469ce636395c98408,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -554,6 +609,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: d57ec60e928915b469ce636395c98408,
+        type: 3}
+      propertyPath: m_Name
+      value: Spawner
       objectReference: {fileID: 0}
     - target: {fileID: -444521105353760620, guid: d57ec60e928915b469ce636395c98408,
         type: 3}
@@ -896,11 +956,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 422333173}
     m_Modifications:
-    - target: {fileID: -927199367670048503, guid: d57ec60e928915b469ce636395c98408,
-        type: 3}
-      propertyPath: m_Name
-      value: Spawner
-      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d57ec60e928915b469ce636395c98408,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -955,6 +1010,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: d57ec60e928915b469ce636395c98408,
+        type: 3}
+      propertyPath: m_Name
+      value: Spawner
       objectReference: {fileID: 0}
     - target: {fileID: -444521105353760620, guid: d57ec60e928915b469ce636395c98408,
         type: 3}
@@ -1297,10 +1357,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1074984854958102258}
     m_Modifications:
-    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
-      propertyPath: m_Name
-      value: MagicianHat
-      objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
@@ -1344,6 +1400,10 @@ PrefabInstance:
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
+      propertyPath: m_Name
+      value: MagicianHat
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}

--- a/Assets/Prefabs/Resources/EditorPlayer.prefab
+++ b/Assets/Prefabs/Resources/EditorPlayer.prefab
@@ -319,6 +319,11 @@ PrefabInstance:
       propertyPath: handSide
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
@@ -378,11 +383,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: handSide
-      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593, type: 3}
@@ -453,6 +453,11 @@ PrefabInstance:
       propertyPath: handSide
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
@@ -512,11 +517,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: handSide
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593, type: 3}
@@ -647,6 +647,26 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8257841525879649555, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 2100344447926330342, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 7521500475243626038, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 3856802733824022515, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fc9f29be05bff9041aa4224b9daf0148, type: 3}
 --- !u!4 &867877281933100492 stripped
@@ -668,10 +688,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4826936438972125842}
     m_Modifications:
-    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
-      propertyPath: m_Name
-      value: MagicianHat
-      objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
@@ -715,6 +731,10 @@ PrefabInstance:
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
+      propertyPath: m_Name
+      value: MagicianHat
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
@@ -802,6 +822,26 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6725829415033737101, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 2887549285048160861, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 8499703945713646488, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 3668921935798983032, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c781111642117e48bc3fee37aae5f24, type: 3}
 --- !u!1 &3168468518105831861 stripped
@@ -888,6 +928,26 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4724688693394326722, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 6586924146612473831, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 472550232652146210, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
+    - target: {fileID: 3327355752699957815, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 1721402359657460489}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 68133f0ebc3140b419b63fd9ee0e7709, type: 3}
 --- !u!1 &6743368886153141708 stripped

--- a/Assets/Prefabs/Resources/OVRPlayer.prefab
+++ b/Assets/Prefabs/Resources/OVRPlayer.prefab
@@ -899,17 +899,37 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6725829415033737101, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 2887549285048160861, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 8499703945713646488, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 3668921935798983032, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c781111642117e48bc3fee37aae5f24, type: 3}
---- !u!1 &1761453429872487697 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5773582039876106695, guid: 0c781111642117e48bc3fee37aae5f24,
-    type: 3}
-  m_PrefabInstance: {fileID: 5219129674270151894}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8473976127911845167 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4465194431200479737, guid: 0c781111642117e48bc3fee37aae5f24,
+    type: 3}
+  m_PrefabInstance: {fileID: 5219129674270151894}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1761453429872487697 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5773582039876106695, guid: 0c781111642117e48bc3fee37aae5f24,
     type: 3}
   m_PrefabInstance: {fileID: 5219129674270151894}
   m_PrefabAsset: {fileID: 0}
@@ -985,17 +1005,37 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4724688693394326722, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 6586924146612473831, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 472550232652146210, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 3327355752699957815, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 68133f0ebc3140b419b63fd9ee0e7709, type: 3}
---- !u!1 &8928527379286783484 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-    type: 3}
-  m_PrefabInstance: {fileID: 6380672977538781569}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1585527324074231234 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+    type: 3}
+  m_PrefabInstance: {fileID: 6380672977538781569}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8928527379286783484 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
     type: 3}
   m_PrefabInstance: {fileID: 6380672977538781569}
   m_PrefabAsset: {fileID: 0}
@@ -1006,15 +1046,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5798643184190185188}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
       value: LeftHand
-      objectReference: {fileID: 0}
-    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: vibration.actionPath
-      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1076,10 +1116,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
-      propertyPath: handSide
-      value: 1
+      propertyPath: vibration.actionPath
+      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1105,16 +1145,16 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6598303500989519652}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6674366615824283496 stripped
+--- !u!114 &220778438965194230 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+  m_CorrespondingSourceObject: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
     type: 3}
   m_PrefabInstance: {fileID: 6598303500989519652}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5290703336778448631}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9922fa266f2093a4089ad4e3b0af5d62, type: 3}
+  m_Script: {fileID: 11500000, guid: 19d28c53e7885da4eb29626d1c4ff334, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &7798023449863762142 stripped
@@ -1153,16 +1193,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 957b3325e4db9c9419a7d3f4b4046aed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &220778438965194230 stripped
+--- !u!114 &6674366615824283496 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+  m_CorrespondingSourceObject: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
     type: 3}
   m_PrefabInstance: {fileID: 6598303500989519652}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5290703336778448631}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19d28c53e7885da4eb29626d1c4ff334, type: 3}
+  m_Script: {fileID: 11500000, guid: 9922fa266f2093a4089ad4e3b0af5d62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &7403788545556986988
@@ -1172,15 +1212,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5798643184190185188}
     m_Modifications:
+    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: handSide
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: m_Name
       value: RightHand
-      objectReference: {fileID: 0}
-    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: vibration.actionPath
-      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1242,10 +1282,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+    - target: {fileID: 6377588284077882066, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
-      propertyPath: handSide
-      value: 2
+      propertyPath: vibration.actionPath
+      value: /actions/default/out/Haptic
       objectReference: {fileID: 0}
     - target: {fileID: 8147850146262060191, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1333,10 +1373,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8482418654403261473}
     m_Modifications:
-    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
-      propertyPath: m_Name
-      value: MagicianHat
-      objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
@@ -1380,6 +1416,10 @@ PrefabInstance:
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
+      propertyPath: m_Name
+      value: MagicianHat
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
@@ -1467,6 +1507,26 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8257841525879649555, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 2100344447926330342, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 7521500475243626038, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
+    - target: {fileID: 3856802733824022515, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 71325662272139836}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fc9f29be05bff9041aa4224b9daf0148, type: 3}
 --- !u!4 &29820092716400847 stripped

--- a/Assets/Prefabs/Resources/SteamVRPlayer.prefab
+++ b/Assets/Prefabs/Resources/SteamVRPlayer.prefab
@@ -543,10 +543,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5699201619636137128}
     m_Modifications:
-    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
-      propertyPath: m_Name
-      value: MagicianHat
-      objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
@@ -590,6 +586,10 @@ PrefabInstance:
     - target: {fileID: 400000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
+      propertyPath: m_Name
+      value: MagicianHat
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 06c4131835f65024586454416f6b1f66, type: 3}
@@ -677,6 +677,26 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6725829415033737101, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 2887549285048160861, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 8499703945713646488, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 3668921935798983032, guid: 0c781111642117e48bc3fee37aae5f24,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c781111642117e48bc3fee37aae5f24, type: 3}
 --- !u!1 &8081944341715014876 stripped
@@ -698,16 +718,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2118341067245113424}
     m_Modifications:
-    - target: {fileID: 1183598243859830188, guid: fc9f29be05bff9041aa4224b9daf0148,
-        type: 3}
-      propertyPath: m_Name
-      value: WallGoalHorizontal
-      objectReference: {fileID: 0}
-    - target: {fileID: 1183598243859830188, guid: fc9f29be05bff9041aa4224b9daf0148,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 9044513101925885330, guid: fc9f29be05bff9041aa4224b9daf0148,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -763,6 +773,36 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 90
       objectReference: {fileID: 0}
+    - target: {fileID: 1183598243859830188, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: m_Name
+      value: WallGoalHorizontal
+      objectReference: {fileID: 0}
+    - target: {fileID: 1183598243859830188, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8257841525879649555, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 2100344447926330342, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 7521500475243626038, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 3856802733824022515, guid: fc9f29be05bff9041aa4224b9daf0148,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fc9f29be05bff9041aa4224b9daf0148, type: 3}
 --- !u!1 &4461725135585429212 stripped
@@ -784,16 +824,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2118341067245113424}
     m_Modifications:
-    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: m_Name
-      value: GoalPost
-      objectReference: {fileID: 0}
-    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5659996650303444035, guid: 68133f0ebc3140b419b63fd9ee0e7709,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -849,6 +879,36 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_Name
+      value: GoalPost
+      objectReference: {fileID: 0}
+    - target: {fileID: 2550220587479786621, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724688693394326722, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 6586924146612473831, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 472550232652146210, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
+    - target: {fileID: 3327355752699957815, guid: 68133f0ebc3140b419b63fd9ee0e7709,
+        type: 3}
+      propertyPath: playerHead
+      value: 
+      objectReference: {fileID: 2118341067245113424}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 68133f0ebc3140b419b63fd9ee0e7709, type: 3}
 --- !u!1 &7445922657630590380 stripped
@@ -870,15 +930,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2118341067558500290}
     m_Modifications:
-    - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: m_Name
-      value: HumanHand
-      objectReference: {fileID: 0}
     - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: handSide
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: m_Name
+      value: HumanHand
       objectReference: {fileID: 0}
     - target: {fileID: 7965826471793230937, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
@@ -1015,15 +1075,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2118341066931277686}
     m_Modifications:
-    - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
-        type: 3}
-      propertyPath: m_Name
-      value: HumanHand
-      objectReference: {fileID: 0}
     - target: {fileID: 518475807796813900, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}
       propertyPath: handSide
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1368452946636138963, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
+        type: 3}
+      propertyPath: m_Name
+      value: HumanHand
       objectReference: {fileID: 0}
     - target: {fileID: 7965826471793230937, guid: 4c4aaf52cbbb82147ac9b92d3dd72593,
         type: 3}

--- a/Assets/Prefabs/WallGoalHorizontal.prefab
+++ b/Assets/Prefabs/WallGoalHorizontal.prefab
@@ -88,7 +88,6 @@ MonoBehaviour:
   - {fileID: 2090186049907920120}
   - {fileID: 7245697247069241218}
   followingMat: {fileID: 2100000, guid: 85d8e1af79d92f74398661f34bcf0ef5, type: 2}
-  stationaryMat: {fileID: 2100000, guid: fc54cad22d1ea2a45b1ef6240ef664e4, type: 2}
   hitMat: {fileID: 2100000, guid: 476fadb7d5abec4479cd603f6c7154d4, type: 2}
 --- !u!114 &7651812208393269088
 MonoBehaviour:
@@ -137,15 +136,15 @@ GameObject:
   m_Component:
   - component: {fileID: 7601408919641224062}
   - component: {fileID: 8257841525879649555}
-  - component: {fileID: 2157848077319250909}
-  - component: {fileID: 5208450816904912982}
+  - component: {fileID: 6985043891521260263}
+  - component: {fileID: 4142698458927430371}
   m_Layer: 8
   m_Name: GoalIndicatorTL
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7601408919641224062
 Transform:
   m_ObjectHideFlags: 0
@@ -154,7 +153,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2534400969197306023}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5, y: 0.5, z: -0.5}
+  m_LocalPosition: {x: -0.5, y: 0.2, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 9044513101925885330}
@@ -172,7 +171,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &2157848077319250909
+  goalType: 1
+  playerHead: {fileID: 0}
+--- !u!114 &6985043891521260263
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -187,14 +188,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 5208450816904912982}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &5208450816904912982
+--- !u!114 &4142698458927430371
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -583,15 +583,15 @@ GameObject:
   m_Component:
   - component: {fileID: 441068810028409839}
   - component: {fileID: 2100344447926330342}
-  - component: {fileID: 4083057644341019980}
-  - component: {fileID: 3268328842659917225}
+  - component: {fileID: 4143301637418858265}
+  - component: {fileID: 4619963225929889937}
   m_Layer: 8
   m_Name: GoalIndicatorTR
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &441068810028409839
 Transform:
   m_ObjectHideFlags: 0
@@ -600,7 +600,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7389807812708907442}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.5, z: -0.5}
+  m_LocalPosition: {x: 0.5, y: 0.2, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 9044513101925885330}
@@ -618,7 +618,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4083057644341019980
+  goalType: 1
+  playerHead: {fileID: 0}
+--- !u!114 &4143301637418858265
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -633,14 +635,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 3268328842659917225}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &3268328842659917225
+--- !u!114 &4619963225929889937
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -756,15 +757,15 @@ GameObject:
   m_Component:
   - component: {fileID: 5817396736246137458}
   - component: {fileID: 7521500475243626038}
-  - component: {fileID: 506067648506113918}
-  - component: {fileID: 7465100930217983017}
+  - component: {fileID: 5396736227401983163}
+  - component: {fileID: 6859061122625618695}
   m_Layer: 8
   m_Name: GoalIndicatorBL
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &5817396736246137458
 Transform:
   m_ObjectHideFlags: 0
@@ -773,7 +774,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8709693317853590614}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5, y: -0.5, z: -0.5}
+  m_LocalPosition: {x: -0.5, y: -0.2, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 9044513101925885330}
@@ -791,7 +792,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &506067648506113918
+  goalType: 1
+  playerHead: {fileID: 0}
+--- !u!114 &5396736227401983163
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -806,14 +809,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 7465100930217983017}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &7465100930217983017
+--- !u!114 &6859061122625618695
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -929,15 +931,15 @@ GameObject:
   m_Component:
   - component: {fileID: 9079009779665630675}
   - component: {fileID: 3856802733824022515}
-  - component: {fileID: 4720122989004097232}
-  - component: {fileID: 5264444197387385755}
+  - component: {fileID: 8805560207169846181}
+  - component: {fileID: 8576786427507019164}
   m_Layer: 8
   m_Name: GoalIndicatorBR
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &9079009779665630675
 Transform:
   m_ObjectHideFlags: 0
@@ -946,7 +948,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9011943716685265294}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: -0.5, z: -0.5}
+  m_LocalPosition: {x: 0.5, y: -0.2, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 9044513101925885330}
@@ -964,7 +966,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4720122989004097232
+  goalType: 1
+  playerHead: {fileID: 0}
+--- !u!114 &8805560207169846181
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -979,14 +983,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 5264444197387385755}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &5264444197387385755
+--- !u!114 &8576786427507019164
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Prefabs/WallGoalVeritcal.prefab
+++ b/Assets/Prefabs/WallGoalVeritcal.prefab
@@ -192,15 +192,15 @@ GameObject:
   m_Component:
   - component: {fileID: 5074962685495742340}
   - component: {fileID: 6725829415033737101}
-  - component: {fileID: 8708538194331347239}
-  - component: {fileID: 7865661914775355842}
+  - component: {fileID: 5440718642654977316}
+  - component: {fileID: 6773819661001326987}
   m_Layer: 8
   m_Name: GoalIndicatorTR
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &5074962685495742340
 Transform:
   m_ObjectHideFlags: 0
@@ -209,7 +209,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2809895560583239129}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.5, z: -0.5}
+  m_LocalPosition: {x: 0.5, y: 0, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4465194431200479737}
@@ -227,7 +227,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &8708538194331347239
+  goalType: 2
+  playerHead: {fileID: 0}
+--- !u!114 &5440718642654977316
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -242,14 +244,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 7865661914775355842}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &7865661914775355842
+--- !u!114 &6773819661001326987
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -365,15 +366,15 @@ GameObject:
   m_Component:
   - component: {fileID: 1209380945776258585}
   - component: {fileID: 2887549285048160861}
-  - component: {fileID: 5149575671704404757}
-  - component: {fileID: 2876185722279022658}
+  - component: {fileID: 7731831143257926021}
+  - component: {fileID: 6984168216005508274}
   m_Layer: 8
   m_Name: GoalIndicatorBL
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1209380945776258585
 Transform:
   m_ObjectHideFlags: 0
@@ -400,7 +401,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5149575671704404757
+  goalType: 2
+  playerHead: {fileID: 0}
+--- !u!114 &7731831143257926021
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -415,14 +418,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 2876185722279022658}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &2876185722279022658
+--- !u!114 &6984168216005508274
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -538,15 +540,15 @@ GameObject:
   m_Component:
   - component: {fileID: 4434921213863467448}
   - component: {fileID: 8499703945713646488}
-  - component: {fileID: 140210598374271675}
-  - component: {fileID: 683436673380210672}
+  - component: {fileID: 1301323989708276803}
+  - component: {fileID: 2726864570514656645}
   m_Layer: 8
   m_Name: GoalIndicatorBR
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &4434921213863467448
 Transform:
   m_ObjectHideFlags: 0
@@ -573,7 +575,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &140210598374271675
+  goalType: 2
+  playerHead: {fileID: 0}
+--- !u!114 &1301323989708276803
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -588,14 +592,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 683436673380210672}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &683436673380210672
+--- !u!114 &2726864570514656645
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -698,7 +701,6 @@ MonoBehaviour:
   - {fileID: 6733667804745326739}
   - {fileID: 2665846565528081385}
   followingMat: {fileID: 2100000, guid: 85d8e1af79d92f74398661f34bcf0ef5, type: 2}
-  stationaryMat: {fileID: 2100000, guid: fc54cad22d1ea2a45b1ef6240ef664e4, type: 2}
   hitMat: {fileID: 2100000, guid: 476fadb7d5abec4479cd603f6c7154d4, type: 2}
 --- !u!114 &3045467696002908939
 MonoBehaviour:
@@ -747,15 +749,15 @@ GameObject:
   m_Component:
   - component: {fileID: 2958512222769913621}
   - component: {fileID: 3668921935798983032}
-  - component: {fileID: 6737712107622944694}
-  - component: {fileID: 593134289300524093}
+  - component: {fileID: 2763643275368560580}
+  - component: {fileID: 7766151962933413080}
   m_Layer: 8
   m_Name: GoalIndicatorTL
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2958512222769913621
 Transform:
   m_ObjectHideFlags: 0
@@ -764,7 +766,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7160475272578346188}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5, y: 0.5, z: -0.5}
+  m_LocalPosition: {x: -0.5, y: 0, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4465194431200479737}
@@ -782,7 +784,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6487f88b6b59d01468a91590e249bb5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &6737712107622944694
+  goalType: 2
+  playerHead: {fileID: 0}
+--- !u!114 &2763643275368560580
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -797,14 +801,13 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  Synchronization: 3
+  Synchronization: 0
   OwnershipTransfer: 0
-  ObservedComponents:
-  - {fileID: 593134289300524093}
+  ObservedComponents: []
   viewIdField: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &593134289300524093
+--- !u!114 &7766151962933413080
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Scripts/GoalIndicator.cs
+++ b/Assets/Scripts/GoalIndicator.cs
@@ -3,19 +3,26 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class GoalIndicator : MonoBehaviour {
+public class GoalIndicator : MonoBehaviourPunCallbacks {
     private static readonly int LENGTH_LINERENDERER = 3;
+    private static readonly float LENGTH_OFFSET = 1.5f;
+    [SerializeField]
+    private GoalType goalType;
     private LineRenderer goalIndicator;
-    private PhotonView pv;
+    [SerializeField]
+    private Transform playerHead = null;
 
     void Start() {
-        pv = GetComponent<PhotonView>();
-        if (!PhotonNetwork.IsConnected || pv.IsMine) {
+        if (!PhotonNetwork.IsConnected || photonView.IsMine) {
             InitGoalIndicator();
         }
     }
 
     private void InitGoalIndicator() {
+        if (playerHead == null) {
+            playerHead = Camera.main.transform;
+        }
+
         goalIndicator = gameObject.AddComponent<LineRenderer>();
         goalIndicator.material = new Material(Shader.Find("Sprites/Default"));
         goalIndicator.widthMultiplier = 0.025f;
@@ -35,14 +42,25 @@ public class GoalIndicator : MonoBehaviour {
 
     // Update is called once per frame
     void Update() {
-        if (!PhotonNetwork.IsConnected || pv.IsMine) {
-            DrawGoalIndicator();
+        if (!PhotonNetwork.IsConnected || photonView.IsMine) {
+            if (goalType == GoalType.REGULAR) {
+                DrawRegGoalIndicator();
+            } else if (goalType == GoalType.HORIZONTAL_WALL || goalType == GoalType.VERITCAL_WALL) {
+                DrawWallGoalIndicator();
+            }
         }
     }
 
-    private void DrawGoalIndicator() {
+    private void DrawRegGoalIndicator() {
         goalIndicator.positionCount = 2;
         goalIndicator.SetPosition(0, this.transform.position);
         goalIndicator.SetPosition(1, -this.transform.forward * LENGTH_LINERENDERER + this.transform.position);
+    }
+
+    private void DrawWallGoalIndicator() {
+        float lengthToRender = Vector3.Distance(playerHead.position, this.transform.position) + LENGTH_OFFSET;
+        goalIndicator.positionCount = 2;
+        goalIndicator.SetPosition(0, this.transform.position);
+        goalIndicator.SetPosition(1, -this.transform.forward * lengthToRender + this.transform.position);
     }
 }


### PR DESCRIPTION
**Description**
Update `GoalIndicator.cs` to give vertical and horizontal wall goals line indicators too. The length of the wall goal indicators will change with the player's distance to the goal. The player's position is considered to be where thee center eye anchor transform position is.

Changed prefabs:
- GoalPost
- WallGoalHorizontal
- WallGoalVertical
- DummyBot
- EditorPlayer
- OVRPlayer
- SteamVRPlayer

@khooroko

**Impact**
If impact is minor, no need for the reviewer to check out the branch to test locally before approval
- [ ] Major
- [x] Medium
- [ ] Minor

**Test Plan**
Pls try k thanks